### PR TITLE
RELEASE of v0.1.0

### DIFF
--- a/changelog/releases/v0.1.0.md
+++ b/changelog/releases/v0.1.0.md
@@ -1,0 +1,5 @@
+## v0.1.0
+
+### Additions
+
+- Initial move to separate repository. ([#1](https://github.com/splicemachine/splicectl/pull/1))

--- a/release/README.md
+++ b/release/README.md
@@ -12,6 +12,7 @@
 - Review changelogs/releases/${RELEASE_VERSION}.md
 - Create and Merge PR
   - If there were fragments ensure that they have been deleted and only 00_template.yaml remains.
+    - `git add -A; git commit -m "RELEASE of ${RELEASE_VERSION}"; git push origin RELEASE_${RELEASE_VERSION}`
 - Pull main
   - `git checkout main; git fetch; git pull`
 - Perform the release


### PR DESCRIPTION
PR to release v0.1.0

## Description

We have migrated the splicectl repository to a separate repository.

## Motivation and Context

This move to a separate repoistory was done in order to take advantage of some automation around documentation, changelog, and release.

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/splicemachine/splicectl/tree/master/changelog/fragments/00-template.yaml))

  - It is important to include the changelog fragment in your PR, this way the changelog will include the correct PR link.
