### PR TITLE
feat: accounts, database CRUD (DBAAS-4410)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ endif
 changelog: check_release_version ## Generate the changelog.
 	@mkdir -p changelog/releases && rm -f changelog/releases/$(RELEASE_VERSION).md
 	go run ./release/changelog/gen-changelog.go -tag=$(RELEASE_VERSION) -changelog=changelog/releases/$(RELEASE_VERSION).md
-	rm -f ./changelog/fragments/!(00-template.yaml)
+	find ./changelog/fragments -type f ! -name 00-template.yaml -delete

--- a/changelog/fragments/create-database.yaml
+++ b/changelog/fragments/create-database.yaml
@@ -1,0 +1,26 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      create splice-database changed to call cloud manager
+        * requires Cloud Manager API to support database/create call
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0

--- a/changelog/fragments/delete-database.yaml
+++ b/changelog/fragments/delete-database.yaml
@@ -1,0 +1,25 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      delete database functionality
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "addition"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0

--- a/changelog/fragments/get-accounts.yaml
+++ b/changelog/fragments/get-accounts.yaml
@@ -1,0 +1,25 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Get CloudManager accounts list
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "addition"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0

--- a/changelog/fragments/get-default-cr.yaml
+++ b/changelog/fragments/get-default-cr.yaml
@@ -1,0 +1,25 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      removed debugging output
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0

--- a/changelog/fragments/list-database.yaml
+++ b/changelog/fragments/list-database.yaml
@@ -1,0 +1,25 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      list database will now prompt for database if not provided
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "bugfix"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0

--- a/changelog/fragments/pause-database.yaml
+++ b/changelog/fragments/pause-database.yaml
@@ -1,0 +1,26 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      pause database functionality
+        * requires cloudmanager api endpoint pauseCluster
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "addition"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0

--- a/changelog/fragments/resume-database.yaml
+++ b/changelog/fragments/resume-database.yaml
@@ -1,0 +1,26 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      resume database functionality
+        * requires cloudmanager api endpoint resumeCluster
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "addition"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0

--- a/changelog/fragments/semver-command.yaml
+++ b/changelog/fragments/semver-command.yaml
@@ -1,0 +1,26 @@
+# entries is a list of entries to include in
+# release notes and/or the migration guide
+entries:
+  - description: >
+      Moved the SemVer checking to each command function
+        * outputs are also driven by the SemVer, output formatting started in v0.0.17 of the API
+
+    # kind is one of:
+    # - addition
+    # - change
+    # - deprecation
+    # - removal
+    # - bugfix
+    kind: "change"
+
+    # Is this a breaking change?
+    breaking: false
+
+    # NOTE: ONLY USE `pull_request_override` WHEN ADDING THIS
+    # FILE FOR A PREVIOUSLY MERGED PULL_REQUEST!
+    #
+    # The generator auto-detects the PR number from the commit
+    # message in which this file was originally added.
+    #
+    # What is the pull request number (without the "#")?
+    # pull_request_override: 0

--- a/cmd/apply_database-cr.go
+++ b/cmd/apply_database-cr.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-resty/resty/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/splicemachine/splicectl/cmd/objects"
@@ -24,6 +26,11 @@ var applyDatabaseCRCmd = &cobra.Command{
     splicectl apply database-cr --database-name splicedb --file ~/tmp/splicedb.json
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+
+		var sv semver.Version
+
+		_, sv = versionDetail.RequirementMet("apply_database-cr")
+
 		var dberr error
 		databaseName, _ := cmd.Flags().GetString("database-name")
 		if len(databaseName) == 0 {
@@ -44,28 +51,56 @@ var applyDatabaseCRCmd = &cobra.Command{
 		if err != nil {
 			logrus.WithError(err).Error("Error setting Database CR Info")
 		}
-		var vvData objects.VaultVersion
-		marshErr := json.Unmarshal([]byte(out), &vvData)
-		if marshErr != nil {
-			logrus.Fatal("Could not unmarshall data", marshErr)
+
+		if semverV1, err := semver.ParseRange(">=0.0.14 <0.0.17"); err != nil {
+			logrus.Fatal("Failed to parse SemVer")
+		} else {
+			if semverV1(sv) {
+				displayApplyDatabaseCRV1(out)
+			}
 		}
 
-		if !formatOverridden {
-			outputFormat = "text"
-		}
-
-		switch strings.ToLower(outputFormat) {
-		case "json":
-			vvData.ToJSON()
-		case "gron":
-			vvData.ToGRON()
-		case "yaml":
-			vvData.ToYAML()
-		case "text", "table":
-			vvData.ToTEXT(noHeaders)
+		if semverV2, err := semver.ParseRange(">=0.0.17"); err != nil {
+			logrus.Fatal("Failed to parse SemVer")
+		} else {
+			if semverV2(sv) {
+				displayApplyDatabaseCRV1(out)
+			}
 		}
 
 	},
+}
+
+func displayApplyDatabaseCRV1(in string) {
+	fmt.Println(in)
+	os.Exit(0)
+}
+
+func displayApplyDatabaseCRV2(in string) {
+	if strings.ToLower(outputFormat) == "raw" {
+		fmt.Println(in)
+		os.Exit(0)
+	}
+	var vvData objects.VaultVersion
+	marshErr := json.Unmarshal([]byte(in), &vvData)
+	if marshErr != nil {
+		logrus.Fatal("Could not unmarshall data", marshErr)
+	}
+
+	if !formatOverridden {
+		outputFormat = "text"
+	}
+
+	switch strings.ToLower(outputFormat) {
+	case "json":
+		vvData.ToJSON()
+	case "gron":
+		vvData.ToGRON()
+	case "yaml":
+		vvData.ToYAML()
+	case "text", "table":
+		vvData.ToTEXT(noHeaders)
+	}
 }
 
 func setDatabaseCR(dbname string, in []byte) (string, error) {

--- a/cmd/apply_database-cr.go
+++ b/cmd/apply_database-cr.go
@@ -26,12 +26,11 @@ var applyDatabaseCRCmd = &cobra.Command{
     splicectl apply database-cr --database-name splicedb --file ~/tmp/splicedb.json
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-
+		var dberr error
 		var sv semver.Version
 
 		_, sv = versionDetail.RequirementMet("apply_database-cr")
 
-		var dberr error
 		databaseName, _ := cmd.Flags().GetString("database-name")
 		if len(databaseName) == 0 {
 			databaseName, dberr = promptForDatabaseName()
@@ -64,7 +63,7 @@ var applyDatabaseCRCmd = &cobra.Command{
 			logrus.Fatal("Failed to parse SemVer")
 		} else {
 			if semverV2(sv) {
-				displayApplyDatabaseCRV1(out)
+				displayApplyDatabaseCRV2(out)
 			}
 		}
 
@@ -77,6 +76,7 @@ func displayApplyDatabaseCRV1(in string) {
 }
 
 func displayApplyDatabaseCRV2(in string) {
+
 	if strings.ToLower(outputFormat) == "raw" {
 		fmt.Println(in)
 		os.Exit(0)

--- a/cmd/apply_image-tag.go
+++ b/cmd/apply_image-tag.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-resty/resty/v2"
 	"github.com/sirupsen/logrus"
 
@@ -24,6 +26,10 @@ var applyImageTagCmd = &cobra.Command{
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		var dberr error
+		var sv semver.Version
+
+		_, sv = versionDetail.RequirementMet("apply_image-tag")
+
 		componentName, _ := cmd.Flags().GetString("component-name")
 		databaseName, _ := cmd.Flags().GetString("database-name")
 		if len(databaseName) == 0 {
@@ -38,8 +44,20 @@ var applyImageTagCmd = &cobra.Command{
 		if err != nil {
 			logrus.WithError(err).Error("Error getting image tag for component")
 		}
-		fmt.Println(out)
+
+		if semverV1, err := semver.ParseRange(">=0.0.16"); err != nil {
+			logrus.Fatal("Failed to parse SemVer")
+		} else {
+			if semverV1(sv) {
+				displayApplyImageTagV1(out)
+			}
+		}
 	},
+}
+
+func displayApplyImageTagV1(in string) {
+	fmt.Println(in)
+	os.Exit(0)
 }
 
 func setDatabaseImageTag(componentName string, databaseName string, imageTag string) (string, error) {

--- a/cmd/create_splice-database.go
+++ b/cmd/create_splice-database.go
@@ -1,11 +1,16 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/sirupsen/logrus"
+	"github.com/splicemachine/splicectl/cmd/objects"
+	"github.com/splicemachine/splicectl/common"
 
 	"github.com/spf13/cobra"
 )
@@ -21,24 +26,52 @@ type AuthError struct {
 }
 
 var createSpliceDatabaseCmd = &cobra.Command{
-	Use:   "splice-database",
-	Short: "Create a SpliceDBCluster KIND",
-	Long:  `Create a SpliceDBCluster KIND`,
+	Use:     "splice-database",
+	Aliases: []string{"database"},
+	Short:   "Create a Splice Machine Database",
+	Long: `EXAMPLES
+	splicectl get accounts
+
+	While you can specify each of the parameters on the command line, it is much
+	easier to create a SKEL yaml file and use that to create the database.
+
+	splicectl create splice-database --skel --account-id <accountid> --cloud-provider <aws|az|gcp|none> > ~/tmp/splicedb-create.yaml
+	# edit the ~/tmp/splicedb-create.yaml
+	splicectl create splice-database --file ~/tmp/splicedb-create.yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		dryRun, _ := cmd.Flags().GetBool("dry-run")
-		databaseName, _ := cmd.Flags().GetString("database-name")
-		dnsPrefix, _ := cmd.Flags().GetString("dns-prefix")
+		// Look for --file first, load that into the structure, then read each
+		// parameters and override the values loaded from the input file
+		skel, _ := cmd.Flags().GetBool("skel")
+		file, _ := cmd.Flags().GetString("file")
+		fileProvided := false
 
-		if len(databaseName) == 0 {
-			logrus.Fatal("--database-name is a required flag")
+		dbReq := objects.DatabaseRequest{}
+
+		if len(file) > 0 {
+			fileBytes, _ := ioutil.ReadFile(file)
+
+			jsonBytes, cerr := common.WantJSON(fileBytes)
+			if cerr != nil {
+				logrus.Fatal("The input data MUST be in either JSON or YAML format")
+			}
+			if len(jsonBytes) > 0 {
+				marshErr := json.Unmarshal(jsonBytes, &dbReq)
+				if marshErr != nil {
+					logrus.Fatal("Could not unmarshall data", marshErr)
+				}
+			}
+			fileProvided = true
 		}
 
-		if len(dnsPrefix) == 0 {
-			logrus.Fatal("--database-name is a required flag")
+		populateRequest(cmd, &dbReq, fileProvided)
+
+		if skel {
+			generateSkel(&dbReq)
+			os.Exit(0)
 		}
 
-		out, err := generateCR(databaseName, dnsPrefix, dryRun)
+		out, err := createSpliceDatabase(&dbReq, false)
 		if err != nil {
 			logrus.WithError(err).Error("Error Generating Default CR Info")
 		}
@@ -46,19 +79,136 @@ var createSpliceDatabaseCmd = &cobra.Command{
 	},
 }
 
-func generateCR(dbname string, dns string, outputonly bool) (string, error) {
+func populateRequest(cmd *cobra.Command, req *objects.DatabaseRequest, fileData bool) {
+
+	requiredList := []string{}
+
+	databaseName, _ := cmd.Flags().GetString("database-name")
+	password, _ := cmd.Flags().GetString("password")
+	accountID, _ := cmd.Flags().GetString("account-id")
+	authorizationCode, _ := cmd.Flags().GetString("authorization-code")
+	backupFrequency, _ := cmd.Flags().GetString("backup-frequency")
+	backupInterval, _ := cmd.Flags().GetInt("backup-interval")
+	keepBackups, _ := cmd.Flags().GetInt("keep-backups")
+	backupStartWindow, _ := cmd.Flags().GetString("backup-start-window")
+	cloudProvider, _ := cmd.Flags().GetString("cloud-provider")
+	sparkExecutors, _ := cmd.Flags().GetInt("spark-executors")
+	regionServers, _ := cmd.Flags().GetInt("region-servers")
+	dedicatedStorage, _ := cmd.Flags().GetBool("dedicated-storage")
+	externalDatasetSize, _ := cmd.Flags().GetInt("external-dataset-size")
+	internalDatasetSize, _ := cmd.Flags().GetInt("internal-dataset-size")
+	enableMLManager, _ := cmd.Flags().GetBool("enable-mlmanager")
+	notebookActiveUsers, _ := cmd.Flags().GetInt("notebook-active-users")
+	notebookExecutors, _ := cmd.Flags().GetInt("notebook-executors")
+	notebookTotalUsers, _ := cmd.Flags().GetInt("notebook-total-users")
+	notebooksPerUser, _ := cmd.Flags().GetInt("notebooks-per-user")
+
+	if cmd.Flags().Changed("database-name") || !fileData {
+		req.Name = databaseName
+	}
+	if cmd.Flags().Changed("password") || !fileData {
+		req.Password = password
+	}
+	if cmd.Flags().Changed("account-id") {
+		req.AccountID = accountID
+	} else {
+		if len(req.AccountID) == 0 || !fileData {
+			selectedAccountID, err := promptForAccountID()
+			if err != nil {
+				requiredList = append(requiredList, "--account-id, obtain from 'splicectl get accounts', or select from list")
+			}
+			req.AccountID = selectedAccountID
+		}
+	}
+	if cmd.Flags().Changed("authorization-code") || !fileData {
+		req.AuthorizationCode = authorizationCode
+	}
+	if cmd.Flags().Changed("backup-frequency") || !fileData {
+		req.BackupFrequency = backupFrequency
+	}
+	if cmd.Flags().Changed("backup-interval") || !fileData {
+		req.BackupInterval = backupInterval
+	}
+	if cmd.Flags().Changed("keep-backups") || !fileData {
+		req.BackupKeepCount = keepBackups
+	}
+	if cmd.Flags().Changed("backup-start-window") || !fileData {
+		req.BackupStartWindow = backupStartWindow
+	}
+	if cmd.Flags().Changed("cloud-provider") {
+		req.CloudProvider = cloudProvider
+	} else {
+		if len(req.CloudProvider) == 0 || !fileData {
+			selectedCSP, err := promptForCSP()
+			if err != nil {
+				requiredList = append(requiredList, "--cloud-provider, (aws|az|gcp|none)")
+			}
+			req.CloudProvider = selectedCSP
+		}
+	}
+	if cmd.Flags().Changed("spark-executors") || !fileData {
+		req.ClusterPowerOlap = sparkExecutors
+	}
+	if cmd.Flags().Changed("region-servers") || !fileData {
+		req.ClusterPowerOltp = regionServers
+	}
+	if cmd.Flags().Changed("dedicated-storage") || !fileData {
+		req.DedicatedStorage = dedicatedStorage
+	}
+	if cmd.Flags().Changed("external-dataset-size") || !fileData {
+		req.ExternalDatasetSizeGb = externalDatasetSize
+	}
+	if cmd.Flags().Changed("internal-dataset-size") || !fileData {
+		req.InternalDatasetSizeGb = internalDatasetSize
+	}
+	if cmd.Flags().Changed("enable-mlmanager") || !fileData {
+		req.MlManager = enableMLManager
+	}
+	if cmd.Flags().Changed("notebook-active-users") || !fileData {
+		req.NotebookActiveUsers = notebookActiveUsers
+	}
+	if cmd.Flags().Changed("notebook-executors") || !fileData {
+		req.NotebookExecutorsPerNotebook = notebookExecutors
+	}
+	if cmd.Flags().Changed("notebook-total-users") || !fileData {
+		req.NotebookTotalUsers = notebookTotalUsers
+	}
+	if cmd.Flags().Changed("notebooks-per-user") || !fileData {
+		req.NotebooksPerUser = notebooksPerUser
+	}
+
+	req.CloudProvider = strings.ToUpper(req.CloudProvider)
+
+	if len(requiredList) > 0 {
+		for _, v := range requiredList {
+			logrus.Warn(fmt.Sprintf("Required parameter not provided: %s", v))
+		}
+		os.Exit(1)
+	}
+}
+
+func generateSkel(dbReq *objects.DatabaseRequest) {
+
+	if !formatOverridden {
+		outputFormat = "yaml"
+	}
+
+	switch strings.ToLower(outputFormat) {
+	case "json", "gron":
+		dbReq.ToJSON()
+	case "yaml", "text", "table":
+		dbReq.ToYAML()
+	}
+
+}
+func createSpliceDatabase(dbReq *objects.DatabaseRequest, outputonly bool) (string, error) {
+
 	restClient := resty.New()
 
-	uri := fmt.Sprintf("splicectl/v1/splicedb/splicedatabase?database-name=%s&dns-prefix=%s&user=%s", dbname, dns, os.Getenv("USER"))
+	uri := "splicectl/v1/splicedb/splicedatabase"
 
 	var resp *resty.Response
 	var resperr error
-
-	logrus.WithFields(logrus.Fields{
-		"dbname":     dbname,
-		"dns":        dns,
-		"outputonly": outputonly,
-	}).Info("Field Values")
 
 	if outputonly {
 		resp, resperr = restClient.R().
@@ -68,11 +218,18 @@ func generateCR(dbname string, dns string, outputonly bool) (string, error) {
 			SetHeader("X-Token-Session", authClient.GetSessionID()).
 			Get(fmt.Sprintf("%s/%s", apiServer, uri))
 	} else {
+
+		reqJSON, enverr := json.MarshalIndent(dbReq, "", "  ")
+		if enverr != nil {
+			logrus.WithError(enverr).Error("Error extracting json")
+			return "", enverr
+		}
 		resp, resperr = restClient.R().
 			SetHeader("Content-Type", "application/json").
 			SetHeader("Accept", "application/json").
 			SetHeader("X-Token-Bearer", authClient.GetTokenBearer()).
 			SetHeader("X-Token-Session", authClient.GetSessionID()).
+			SetBody(reqJSON).
 			Post(fmt.Sprintf("%s/%s", apiServer, uri))
 	}
 	if resperr != nil {
@@ -87,8 +244,27 @@ func generateCR(dbname string, dns string, outputonly bool) (string, error) {
 func init() {
 	createCmd.AddCommand(createSpliceDatabaseCmd)
 
-	createSpliceDatabaseCmd.Flags().BoolP("dry-run", "", false, "Output data rather than create the K8s resource")
-	createSpliceDatabaseCmd.Flags().StringP("database-name", "d", "test", "Specify the Splice Machine Database Cluster Name")
-	createSpliceDatabaseCmd.Flags().StringP("dns-prefix", "p", "test", "Specify the Splice Machine Database DNS Prefix/K8s Namespace")
+	createSpliceDatabaseCmd.Flags().BoolP("skel", "s", false, "Generate a skeleton values file for submission")
+	createSpliceDatabaseCmd.Flags().StringP("file", "f", "", "Specify the input file")
+
+	createSpliceDatabaseCmd.Flags().StringP("database-name", "d", "test", "Specify the Splice Machine Database Cluster Name (default=test)")
+	createSpliceDatabaseCmd.Flags().String("password", "admin", "Specify the Splice Machine Database Password (default=admin)")
+	createSpliceDatabaseCmd.Flags().String("account-id", "", "Specify the Cloud Manager Account ID to associate the database to")
+	createSpliceDatabaseCmd.Flags().String("authorization-code", "", "Specify the Authorization Code")
+	createSpliceDatabaseCmd.Flags().String("backup-frequency", "daily", "Specify the Backup Frequency (default=daily)")
+	createSpliceDatabaseCmd.Flags().Int("backup-interval", 1, "Specify the Backup Interval (default=1)")
+	createSpliceDatabaseCmd.Flags().Int("keep-backups", 1, "Specify the Backup Keep Count (default=1)")
+	createSpliceDatabaseCmd.Flags().String("backup-start-window", "02:30", "Specify the Backup Start Window (default=02:30)")
+	createSpliceDatabaseCmd.Flags().String("cloud-provider", "", "Specify the Cloud Provider (az|aws|gcp|none)")
+	createSpliceDatabaseCmd.Flags().Int("spark-executors", 4, "Specify the number of Spark Executors/OLAP (default=4)")
+	createSpliceDatabaseCmd.Flags().Int("region-servers", 4, "Specify the number of Region Servers/OLTP (default=4)")
+	createSpliceDatabaseCmd.Flags().Bool("dedicated-storage", false, "Specify if dedicated storage should be used")
+	createSpliceDatabaseCmd.Flags().Int("external-dataset-size", 0, "Specify the size (GB) of the external storage (default=0)")
+	createSpliceDatabaseCmd.Flags().Int("internal-dataset-size", 1, "Specify the size (GB) of the internal storage (default=1)")
+	createSpliceDatabaseCmd.Flags().Bool("enable-mlmanager", false, "Enable the ML Manager features of the database (default=false)")
+	createSpliceDatabaseCmd.Flags().Int("notebook-active-users", 4, "Specify the max number of active Jupyter notebook sessions (default=4)")
+	createSpliceDatabaseCmd.Flags().Int("notebook-executors", 2, "Specify the max number Spark Executors per notebook (default=2)")
+	createSpliceDatabaseCmd.Flags().Int("notebook-total-users", 10, "Specify the max notebook users (default=10)")
+	createSpliceDatabaseCmd.Flags().Int("notebooks-per-user", 2, "Specify the max number of notebooks per user (default=2)")
 
 }

--- a/cmd/create_splice-database.go
+++ b/cmd/create_splice-database.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-resty/resty/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/splicemachine/splicectl/cmd/objects"
@@ -39,6 +40,10 @@ var createSpliceDatabaseCmd = &cobra.Command{
 	# edit the ~/tmp/splicedb-create.yaml
 	splicectl create splice-database --file ~/tmp/splicedb-create.yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
+
+		var sv semver.Version
+
+		_, sv = versionDetail.RequirementMet("create_splice-database")
 
 		// Look for --file first, load that into the structure, then read each
 		// parameters and override the values loaded from the input file
@@ -75,8 +80,20 @@ var createSpliceDatabaseCmd = &cobra.Command{
 		if err != nil {
 			logrus.WithError(err).Error("Error Generating Default CR Info")
 		}
-		fmt.Println(out)
+
+		if semverV1, err := semver.ParseRange(">=0.1.7"); err != nil {
+			logrus.Fatal("Failed to parse SemVer")
+		} else {
+			if semverV1(sv) {
+				displayCreateSpliceDatabaseV1(out)
+			}
+		}
 	},
+}
+
+func displayCreateSpliceDatabaseV1(in string) {
+	fmt.Println(in)
+	os.Exit(0)
 }
 
 func populateRequest(cmd *cobra.Command, req *objects.DatabaseRequest, fileData bool) {

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/splicemachine/splicectl/cmd/objects"
+)
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Args:  cobra.MinimumNArgs(0),
+	Short: "Delete Cluster Databases",
+	Long: `EXAMPLES
+	splicectl list databases
+	splicectl delete --database-name <database> --delete
+
+	  * The '--delete' is required as a validation for the deletion request`,
+	Run: func(cmd *cobra.Command, args []string) {
+		var dberr error
+		verifyDelete, _ := cmd.Flags().GetBool("delete")
+		databaseName, _ := cmd.Flags().GetString("database-name")
+		if len(databaseName) == 0 {
+			databaseName, dberr = promptForDatabaseName()
+			if dberr != nil {
+				logrus.Fatal("Could not get a list of Databases", dberr)
+			}
+		}
+		if verifyDelete {
+			clusterID := getMatchingClusterID(databaseName)
+			if len(clusterID) > 0 {
+				out, err := deleteDatabase(clusterID)
+				if err != nil {
+					logrus.Warn("Deleting database failed.")
+				}
+				fmt.Println(out)
+			} else {
+				logrus.Fatal("Unable to determine ClusterId from Database Name")
+			}
+		} else {
+			logrus.Fatal("You MUST specify --delete on the commandline to validate the deletion")
+		}
+	},
+}
+
+func getMatchingClusterID(db string) string {
+	dbJSON, err := getDatabaseList()
+	if err != nil {
+		logrus.WithError(err).Fatal("Error retreiving ClusterId list")
+	}
+	var dbList objects.DatabaseList
+
+	marshErr := json.Unmarshal([]byte(dbJSON), &dbList)
+	if marshErr != nil {
+		logrus.Fatal("Could not unmarshall database list for ClusterId", marshErr)
+	}
+
+	for _, v := range dbList.Clusters {
+		if v.DcosAppId == db {
+			return v.ClusterId
+		}
+	}
+
+	return ""
+}
+
+func deleteDatabase(cid string) (string, error) {
+	restClient := resty.New()
+
+	uri := fmt.Sprintf("splicectl/v1/splicedb/splicedatabasedelete?database-name=%s", cid)
+
+	var resp *resty.Response
+	var resperr error
+
+	resp, resperr = restClient.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetHeader("X-Token-Bearer", authClient.GetTokenBearer()).
+		SetHeader("X-Token-Session", authClient.GetSessionID()).
+		Delete(fmt.Sprintf("%s/%s", apiServer, uri))
+	if resperr != nil {
+		logrus.WithError(resperr).Error("Error getting Default CR Info")
+		return "", resperr
+	}
+
+	return string(resp.Body()[:]), nil
+
+}
+
+func init() {
+	rootCmd.AddCommand(deleteCmd)
+	deleteCmd.Flags().StringP("database-name", "d", "", "Specify the Splice Machine Database to Pause")
+	deleteCmd.Flags().Bool("delete", false, "Verification parameter to perform the deletion")
+}

--- a/cmd/get_accounts.go
+++ b/cmd/get_accounts.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/sirupsen/logrus"
+	"github.com/splicemachine/splicectl/cmd/objects"
+
+	"github.com/spf13/cobra"
+)
+
+var getAccountsCmd = &cobra.Command{
+	Use:   "accounts",
+	Short: "Get a list of Cloud Manager Accounts",
+	Long: `EXAMPLES
+	splicectl get accounts
+
+	    * if no accounts are listed, you will need to logon to the Ops Center
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		out, err := getAccounts()
+		if err != nil {
+			logrus.WithError(err).Error("Error getting Default CR Info")
+		}
+
+		var accounts objects.AccountList
+
+		marshErr := json.Unmarshal([]byte(out), &accounts)
+		if marshErr != nil {
+			logrus.Fatal("Could not unmarshall data", marshErr)
+		}
+
+		if !formatOverridden {
+			outputFormat = "text"
+		}
+
+		switch strings.ToLower(outputFormat) {
+
+		case "json":
+			accounts.ToJSON()
+		case "gron":
+			accounts.ToGRON()
+		case "yaml":
+			accounts.ToYAML()
+		case "text", "table":
+			accounts.ToTEXT(noHeaders)
+		}
+	},
+}
+
+func getAccounts() (string, error) {
+	restClient := resty.New()
+
+	uri := "splicectl/v1/cm/accounts"
+	resp, resperr := restClient.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetHeader("X-Token-Bearer", authClient.GetTokenBearer()).
+		SetHeader("X-Token-Session", authClient.GetSessionID()).
+		Get(fmt.Sprintf("%s/%s", apiServer, uri))
+
+	if resperr != nil {
+		logrus.WithError(resperr).Error("Error getting Account List Info")
+		return "", resperr
+	}
+
+	return string(resp.Body()[:]), nil
+
+}
+
+func init() {
+	getCmd.AddCommand(getAccountsCmd)
+}

--- a/cmd/get_database-status.go
+++ b/cmd/get_database-status.go
@@ -25,12 +25,12 @@ var getDatabaseStatus = &cobra.Command{
 			}
 		}
 
-		out, err := getDatabaseStatusData( databaseName)
+		out, err := getDatabaseStatusData(databaseName)
 		if err != nil {
 			logrus.WithError(err).Error("Error getting status of database ")
 		}
 
-	    fmt.Println(out)
+		fmt.Println(out)
 
 	},
 }
@@ -56,9 +56,5 @@ func getDatabaseStatusData(databaseName string) (string, error) {
 
 func init() {
 	getCmd.AddCommand(getDatabaseStatus)
-
 	getDatabaseStatus.Flags().StringP("database-name", "d", "", "Specify the database name")
-
-	getDatabaseStatus.MarkFlagRequired("database-name")
-
 }

--- a/cmd/get_database-status.go
+++ b/cmd/get_database-status.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-resty/resty/v2"
 	"github.com/sirupsen/logrus"
 
@@ -17,6 +19,10 @@ var getDatabaseStatus = &cobra.Command{
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		var dberr error
+		var sv semver.Version
+
+		_, sv = versionDetail.RequirementMet("get_database-status")
+
 		databaseName, _ := cmd.Flags().GetString("database-name")
 		if len(databaseName) == 0 {
 			databaseName, dberr = promptForDatabaseName()
@@ -30,9 +36,19 @@ var getDatabaseStatus = &cobra.Command{
 			logrus.WithError(err).Error("Error getting status of database ")
 		}
 
-		fmt.Println(out)
-
+		if semverV1, err := semver.ParseRange(">=0.1.6"); err != nil {
+			logrus.Fatal("Failed to parse SemVer")
+		} else {
+			if semverV1(sv) {
+				displayGetDatabaseStatusV1(out)
+			}
+		}
 	},
+}
+
+func displayGetDatabaseStatusV1(in string) {
+	fmt.Println(in)
+	os.Exit(0)
 }
 
 func getDatabaseStatusData(databaseName string) (string, error) {

--- a/cmd/get_default-cr.go
+++ b/cmd/get_default-cr.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-resty/resty/v2"
 	"github.com/sirupsen/logrus"
 
@@ -21,45 +23,80 @@ var getDefaultCRCmd = &cobra.Command{
 	splicectl get default-cr -o json > ~/tmp/default-cr.json
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+
+		var sv semver.Version
+
+		_, sv = versionDetail.RequirementMet("get_default-cr")
+
 		version, _ := cmd.Flags().GetInt("version")
 		out, err := getDefaultCR(version)
 		if err != nil {
 			logrus.WithError(err).Error("Error getting Default CR Info")
 		}
 
-		var defaultCr map[string]interface{}
-
-		marshErr := json.Unmarshal([]byte(out), &defaultCr)
-		if marshErr != nil {
-			logrus.Fatal("Could not unmarshall data", marshErr)
-		}
-
-		if !formatOverridden {
-			outputFormat = "yaml"
-		}
-
-		switch strings.ToLower(outputFormat) {
-		case "json":
-			fmt.Println(string(out[:]))
-		case "gron":
-			subReader := strings.NewReader(string(out[:]))
-			subValues := &bytes.Buffer{}
-			ges := gron.NewGron(subReader, subValues)
-			ges.SetMonochrome(false)
-			serr := ges.ToGron()
-			if serr != nil {
-				logrus.Error("Problem generating gron syntax", serr)
-			} else {
-				fmt.Println(string(subValues.Bytes()))
+		if semverV1, err := semver.ParseRange(">=0.0.14 <0.0.17"); err != nil {
+			logrus.Fatal("Failed to parse SemVer")
+		} else {
+			if semverV1(sv) {
+				displayGetDefaultCRV1(out)
 			}
-		case "yaml", "text", "table":
-			rawDefaultCr, crerr := yaml.Marshal(defaultCr)
-			if crerr != nil {
-				logrus.WithError(crerr).Error("Failed to convert to YAML")
-			}
-			fmt.Println(string(rawDefaultCr[:]))
 		}
+
+		if semverV2, err := semver.ParseRange(">=0.0.17"); err != nil {
+			logrus.Fatal("Failed to parse SemVer")
+		} else {
+			if semverV2(sv) {
+				displayGetDefaultCRV2(out)
+			}
+		}
+
 	},
+}
+
+func displayGetDefaultCRV1(in string) {
+	fmt.Println(in)
+	os.Exit(0)
+}
+
+func displayGetDefaultCRV2(in string) {
+	if strings.ToLower(outputFormat) == "raw" {
+		fmt.Println(in)
+		os.Exit(0)
+	}
+
+	var defaultCr map[string]interface{}
+
+	marshErr := json.Unmarshal([]byte(in), &defaultCr)
+	if marshErr != nil {
+		logrus.Fatal("Could not unmarshall data", marshErr)
+	}
+
+	if !formatOverridden {
+		outputFormat = "yaml"
+	}
+
+	switch strings.ToLower(outputFormat) {
+	case "json":
+		fmt.Println(string(in[:]))
+	case "gron":
+		subReader := strings.NewReader(string(in[:]))
+		subValues := &bytes.Buffer{}
+		ges := gron.NewGron(subReader, subValues)
+		ges.SetMonochrome(false)
+		serr := ges.ToGron()
+		if serr != nil {
+			logrus.Error("Problem generating gron syntax", serr)
+		} else {
+			fmt.Println(string(subValues.Bytes()))
+		}
+	case "yaml", "text", "table":
+		rawDefaultCr, crerr := yaml.Marshal(defaultCr)
+		if crerr != nil {
+			logrus.WithError(crerr).Error("Failed to convert to YAML")
+		}
+		fmt.Println(string(rawDefaultCr[:]))
+	}
+
 }
 
 func getDefaultCR(ver int) (string, error) {

--- a/cmd/get_default-cr.go
+++ b/cmd/get_default-cr.go
@@ -27,7 +27,6 @@ var getDefaultCRCmd = &cobra.Command{
 			logrus.WithError(err).Error("Error getting Default CR Info")
 		}
 
-		fmt.Println(out)
 		var defaultCr map[string]interface{}
 
 		marshErr := json.Unmarshal([]byte(out), &defaultCr)

--- a/cmd/objects/account-list.go
+++ b/cmd/objects/account-list.go
@@ -1,0 +1,110 @@
+package objects
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/maahsome/gron"
+	"github.com/olekukonko/tablewriter"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+)
+
+// AccountList - Data to read from CM Postgres
+type AccountList struct {
+	Accounts []CMUserAccount
+}
+
+// CMUserAccount - Data fields from CM Accounts Postres Tables
+type CMUserAccount struct {
+	AccountID string `json:"accountId"`
+	EMail     string `json:"email"`
+	FirstName string `json:"firstName"`
+	LastName  string `json:"lastName"`
+}
+
+// ToJSON - Write the output as JSON
+func (accountList *AccountList) ToJSON() error {
+
+	listJSON, enverr := json.MarshalIndent(accountList, "", "  ")
+	if enverr != nil {
+		logrus.WithError(enverr).Error("Error extracting json")
+		return enverr
+	} else {
+		fmt.Println(string(listJSON[:]))
+	}
+
+	return nil
+
+}
+
+// ToGRON - Write the output as GRON
+func (accountList *AccountList) ToGRON() error {
+	listJSON, enverr := json.MarshalIndent(accountList, "", "  ")
+	if enverr != nil {
+		logrus.WithError(enverr).Error("Error extracting json")
+		return enverr
+	}
+
+	subReader := strings.NewReader(string(listJSON[:]))
+	subValues := &bytes.Buffer{}
+	ges := gron.NewGron(subReader, subValues)
+	ges.SetMonochrome(false)
+	serr := ges.ToGron()
+	if serr != nil {
+		logrus.Error("Problem generating gron syntax", serr)
+		return serr
+	}
+	fmt.Println(string(subValues.Bytes()))
+
+	return nil
+
+}
+
+// ToYAML - Write the output as YAML
+func (accountList *AccountList) ToYAML() error {
+
+	listYAML, enverr := yaml.Marshal(accountList)
+	if enverr != nil {
+		logrus.WithError(enverr).Error("Error extracting yaml")
+		return enverr
+	} else {
+		fmt.Println(string(listYAML[:]))
+	}
+	return nil
+
+}
+
+// ToTEXT - Write the output as TEXT
+func (accountList *AccountList) ToTEXT(noHeaders bool) error {
+
+	var row []string
+
+	// ******************** TableWriter *******************************
+	table := tablewriter.NewWriter(os.Stdout)
+	if !noHeaders {
+		table.SetHeader([]string{"ACCOUNTID", "EMAIL", "FIRSTNAME", "LASTNAME"})
+		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	}
+	table.SetAutoWrapText(false)
+	table.SetAutoFormatHeaders(true)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetTablePadding("\t") // pad with tabs
+	table.SetNoWhiteSpace(true)
+	for _, v := range accountList.Accounts {
+		row = []string{v.AccountID, v.EMail, v.FirstName, v.LastName}
+		table.Append(row)
+	}
+	table.Render()
+
+	return nil
+
+}

--- a/cmd/objects/database-list.go
+++ b/cmd/objects/database-list.go
@@ -118,7 +118,7 @@ func (databaseList *DatabaseList) ToTEXT(noHeaders bool) error {
 	// ******************** TableWriter *******************************
 	table := tablewriter.NewWriter(os.Stdout)
 	if !noHeaders {
-		table.SetHeader([]string{"DATABASE", "NAMESPACE", "STATUS"})
+		table.SetHeader([]string{"DATABASE", "NAMESPACE", "STATUS", "CLUSTER_ID"})
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	}
 	table.SetAutoWrapText(false)
@@ -132,9 +132,8 @@ func (databaseList *DatabaseList) ToTEXT(noHeaders bool) error {
 	table.SetTablePadding("\t") // pad with tabs
 	table.SetNoWhiteSpace(true)
 	for _, v := range databaseList.Clusters {
-		row = []string{v.DcosAppId, v.Namespace, v.Status}
+		row = []string{v.DcosAppId, v.Namespace, v.Status, v.ClusterId}
 		table.Append(row)
-
 	}
 	table.Render()
 

--- a/cmd/objects/database-skel.go
+++ b/cmd/objects/database-skel.go
@@ -1,0 +1,61 @@
+package objects
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+)
+
+// DatabaseRequest - Cloud Manager Database Request
+type DatabaseRequest struct {
+	AccountID                    string `json:"accountId"`
+	AuthorizationCode            string `json:"authorizationCode"`
+	BackupFrequency              string `json:"backupFrequency"`
+	BackupInterval               int    `json:"backupInterval"`
+	BackupKeepCount              int    `json:"backupKeepCount"`
+	BackupStartWindow            string `json:"backupStartWindow"`
+	CloudProvider                string `json:"cloudProvider"`
+	ClusterPowerOlap             int    `json:"clusterPowerOlap"`
+	ClusterPowerOltp             int    `json:"clusterPowerOltp"`
+	DedicatedStorage             bool   `json:"dedicatedStorage"`
+	ExternalDatasetSizeGb        int    `json:"externalDatasetSizeGb"`
+	InternalDatasetSizeGb        int    `json:"internalDatasetSizeGb"`
+	MlManager                    bool   `json:"mlManager"`
+	Name                         string `json:"name"`
+	NotebookActiveUsers          int    `json:"notebookActiveUsers"`
+	NotebookExecutorsPerNotebook int    `json:"notebookExecutorsPerNotebook"`
+	NotebookTotalUsers           int    `json:"notebookTotalUsers"`
+	NotebooksPerUser             int    `json:"notebooksPerUser"`
+	Password                     string `json:"password"`
+	// Region                       string `json:"region"`
+}
+
+// ToJSON - Write the output as JSON
+func (r *DatabaseRequest) ToJSON() error {
+
+	rJSON, enverr := json.MarshalIndent(r, "", "  ")
+	if enverr != nil {
+		logrus.WithError(enverr).Error("Error extracting json")
+		return enverr
+	}
+	fmt.Println(string(rJSON[:]))
+
+	return nil
+
+}
+
+// ToYAML - Write the output as YAML
+func (r *DatabaseRequest) ToYAML() error {
+
+	rYAML, enverr := yaml.Marshal(r)
+	if enverr != nil {
+		logrus.WithError(enverr).Error("Error extracting yaml")
+		return enverr
+	}
+	fmt.Println(string(rYAML[:]))
+
+	return nil
+
+}

--- a/cmd/objects/version.go
+++ b/cmd/objects/version.go
@@ -7,11 +7,49 @@ import (
 	"os"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"github.com/maahsome/gron"
 	"github.com/olekukonko/tablewriter"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
+
+// ApplyCmSettings - lookup names
+const ApplyCmSettings = "apply_cm-settings"
+
+// CommandVersions - map used to determine compatibility of API server
+var CommandVersions = map[string]string{
+	"apply_cm-settings":        "0.1.6",
+	"apply_database-cr":        "0.0.14",
+	"apply_default-cr":         "0.0.14",
+	"apply_image-tag":          "0.0.16",
+	"apply_system-settings":    "0.0.14",
+	"apply_vault-key":          "0.0.14",
+	"create_splice-database":   "0.1.7",
+	"delete":                   "0.1.7",
+	"get_accounts":             "0.1.7",
+	"get_cm-settings":          "0.1.6",
+	"get_database-cr":          "0.0.14",
+	"get_database-status":      "0.1.6",
+	"get_default-cr":           "0.0.14",
+	"get_image-tag":            "0.0.16",
+	"get_system-settings":      "0.0.14",
+	"get_vault-key":            "0.0.14",
+	"list_database":            "0.0.14",
+	"pause":                    "0.1.7",
+	"restart_database":         "0.1.6",
+	"resume":                   "0.1.7",
+	"rollback_cm-settings":     "0.1.6",
+	"rollback_database-cr":     "0.0.15",
+	"rollback_default-cr":      "0.0.15",
+	"rollback_system-settings": "0.0.15",
+	"rollback_vault-key":       "0.0.15",
+	"versions_cm-settings":     "0.1.6",
+	"versions_database-cr":     "0.0.15",
+	"versions_default-cr":      "0.0.15",
+	"versions_system-settings": "0.0.15",
+	"versions_vault-key":       "0.0.15",
+}
 
 // Version - Structure for Version Info
 type Version struct {
@@ -27,6 +65,26 @@ type BaseVersion struct {
 	SemVer    string `json:"SemVer"`
 	GitCommit string `json:"GitCommit"`
 	BuildDate string `json:"BuildDate"`
+}
+
+// RequirementMet - Check if the command is supported by the server version
+func (v *Version) RequirementMet(command string) (semver.Version, semver.Version) {
+	cv, err := semver.Parse(CommandVersions[command])
+	if err != nil {
+		logrus.Warn(fmt.Sprintf("Error parsing SemVer for %s", CommandVersions[command]))
+	}
+
+	sv, serr := semver.Parse(strings.Replace(v.VersionInfo.Server.SemVer, "v", "", 1))
+	if serr != nil {
+		logrus.Warn(fmt.Sprintf("Error parsing SemVer for %s", v.VersionInfo.Server.SemVer))
+	}
+
+	if sv.GTE(cv) {
+		return cv, sv
+	}
+	logrus.Fatal(fmt.Sprintf("The API server, version %s, does not support this call, the version needs to be v%s or higher", v.VersionInfo.Server.SemVer, CommandVersions[command]))
+	// Clearly we will never get here, though the compiler complains.
+	return semver.Version{}, semver.Version{}
 }
 
 // ToJSON - Write the output as JSON

--- a/cmd/pause.go
+++ b/cmd/pause.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/splicemachine/splicectl/cmd/objects"
+)
+
+var pauseCmd = &cobra.Command{
+	Use:   "pause",
+	Args:  cobra.MinimumNArgs(0),
+	Short: "Pause Cluster Databases",
+	Long: `EXAMPLES
+	splicectl list databases
+	splicectl pause --database-name <database> --message "<message>"`,
+	Run: func(cmd *cobra.Command, args []string) {
+		var dberr error
+		message, _ := cmd.Flags().GetString("message")
+		databaseName, _ := cmd.Flags().GetString("database-name")
+		if len(databaseName) == 0 {
+			databaseName, dberr = promptForDatabaseName()
+			if dberr != nil {
+				logrus.Fatal("Could not get a list of Databases", dberr)
+			}
+		}
+		if isDatabaseActive(databaseName) {
+			out, err := pauseDatabase(databaseName, message)
+			if err != nil {
+				logrus.Warn("Pausing database failed.")
+			}
+			fmt.Println(out)
+		} else {
+			logrus.Warn("The database is not listed as Active, not paused")
+		}
+
+	},
+}
+
+func isDatabaseActive(db string) bool {
+	dbJSON, err := getDatabaseList()
+	if err != nil {
+		logrus.WithError(err).Fatal("Error retreiving ClusterId list")
+	}
+	var dbList objects.DatabaseList
+
+	marshErr := json.Unmarshal([]byte(dbJSON), &dbList)
+	if marshErr != nil {
+		logrus.Fatal("Could not unmarshall database list for ClusterId", marshErr)
+	}
+
+	for _, v := range dbList.Clusters {
+		if v.DcosAppId == db {
+			if v.Status == "Active" {
+				return true
+			}
+			return false
+		}
+	}
+	return false
+}
+
+func pauseDatabase(db string, msg string) (string, error) {
+	restClient := resty.New()
+
+	uri := "splicectl/v1/splicedb/splicedatabasepause"
+
+	var resp *resty.Response
+	var resperr error
+
+	reqJSON := fmt.Sprintf("{ \"appId\": \"%s\", \"message\": \"%s\" }", db, msg)
+	resp, resperr = restClient.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetHeader("X-Token-Bearer", authClient.GetTokenBearer()).
+		SetHeader("X-Token-Session", authClient.GetSessionID()).
+		SetBody(reqJSON).
+		Post(fmt.Sprintf("%s/%s", apiServer, uri))
+	if resperr != nil {
+		logrus.WithError(resperr).Error("Error getting Default CR Info")
+		return "", resperr
+	}
+
+	return string(resp.Body()[:]), nil
+
+}
+
+func init() {
+	rootCmd.AddCommand(pauseCmd)
+	pauseCmd.Flags().StringP("database-name", "d", "", "Specify the Splice Machine Database to Pause")
+	pauseCmd.Flags().StringP("message", "m", "", "Add a message to the database log")
+}

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-resty/resty/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -19,6 +21,10 @@ var resumeCmd = &cobra.Command{
 	splicectl resume --database-name <database> --message "<message>"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var dberr error
+		var sv semver.Version
+
+		_, sv = versionDetail.RequirementMet("resume")
+
 		message, _ := cmd.Flags().GetString("message")
 		databaseName, _ := cmd.Flags().GetString("database-name")
 		if len(databaseName) == 0 {
@@ -32,12 +38,24 @@ var resumeCmd = &cobra.Command{
 			if err != nil {
 				logrus.Warn("Resuming database failed.")
 			}
-			fmt.Println(out)
+
+			if semverV1, err := semver.ParseRange(">=0.1.7"); err != nil {
+				logrus.Fatal("Failed to parse SemVer")
+			} else {
+				if semverV1(sv) {
+					displayResumeDatabaseV1(out)
+				}
+			}
 		} else {
 			logrus.Warn("The database is not listed as Paused, not resuming")
 		}
 
 	},
+}
+
+func displayResumeDatabaseV1(in string) {
+	fmt.Println(in)
+	os.Exit(0)
 }
 
 func isDatabasePaused(db string) bool {

--- a/cmd/rollback_database-cr.go
+++ b/cmd/rollback_database-cr.go
@@ -3,8 +3,10 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-resty/resty/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/splicemachine/splicectl/cmd/objects"
@@ -22,6 +24,10 @@ var rollbackDatabaseCRCmd = &cobra.Command{
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		var dberr error
+		var sv semver.Version
+
+		_, sv = versionDetail.RequirementMet("rollback_database-cr")
+
 		databaseName, _ := cmd.Flags().GetString("database-name")
 		if len(databaseName) == 0 {
 			databaseName, dberr = promptForDatabaseName()
@@ -34,28 +40,55 @@ var rollbackDatabaseCRCmd = &cobra.Command{
 		if err != nil {
 			logrus.WithError(err).Error("Error getting Database CR Info")
 		}
-		var vvData objects.VaultVersion
-		marshErr := json.Unmarshal([]byte(out), &vvData)
-		if marshErr != nil {
-			logrus.Fatal("Could not unmarshall data", marshErr)
+
+		if semverV1, err := semver.ParseRange(">=0.0.15 <0.0.17"); err != nil {
+			logrus.Fatal("Failed to parse SemVer")
+		} else {
+			if semverV1(sv) {
+				displayRollbackDatabaseCRV1(out)
+			}
 		}
 
-		if !formatOverridden {
-			outputFormat = "text"
+		if semverV2, err := semver.ParseRange(">=0.0.17"); err != nil {
+			logrus.Fatal("Failed to parse SemVer")
+		} else {
+			if semverV2(sv) {
+				displayRollbackDatabaseCRV2(out)
+			}
 		}
-
-		switch strings.ToLower(outputFormat) {
-		case "json":
-			vvData.ToJSON()
-		case "gron":
-			vvData.ToGRON()
-		case "yaml":
-			vvData.ToYAML()
-		case "text", "table":
-			vvData.ToTEXT(noHeaders)
-		}
-
 	},
+}
+
+func displayRollbackDatabaseCRV1(in string) {
+	fmt.Println(in)
+	os.Exit(0)
+}
+
+func displayRollbackDatabaseCRV2(in string) {
+	if strings.ToLower(outputFormat) == "raw" {
+		fmt.Println(in)
+		os.Exit(0)
+	}
+	var vvData objects.VaultVersion
+	marshErr := json.Unmarshal([]byte(in), &vvData)
+	if marshErr != nil {
+		logrus.Fatal("Could not unmarshall data", marshErr)
+	}
+
+	if !formatOverridden {
+		outputFormat = "text"
+	}
+
+	switch strings.ToLower(outputFormat) {
+	case "json":
+		vvData.ToJSON()
+	case "gron":
+		vvData.ToGRON()
+	case "yaml":
+		vvData.ToYAML()
+	case "text", "table":
+		vvData.ToTEXT(noHeaders)
+	}
 }
 
 func rollbackDatabaseCR(dbname string, ver int) (string, error) {

--- a/cmd/rollback_system-settings.go
+++ b/cmd/rollback_system-settings.go
@@ -3,8 +3,10 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-resty/resty/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/splicemachine/splicectl/cmd/objects"
@@ -20,33 +22,65 @@ var rollbackSystemSettingsCmd = &cobra.Command{
 	splicectl rollback system-settings --version 2
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+
+		var sv semver.Version
+
+		_, sv = versionDetail.RequirementMet("rollback_system-settings")
+
 		version, _ := cmd.Flags().GetInt("version")
 		out, err := rollbackSystemSettings(version)
 		if err != nil {
 			logrus.WithError(err).Error("Error rolling back System Settings")
 		}
-		var vvData objects.VaultVersion
-		marshErr := json.Unmarshal([]byte(out), &vvData)
-		if marshErr != nil {
-			logrus.Fatal("Could not unmarshall data", marshErr)
+
+		if semverV1, err := semver.ParseRange(">=0.0.15 <0.0.17"); err != nil {
+			logrus.Fatal("Failed to parse SemVer")
+		} else {
+			if semverV1(sv) {
+				displayRollbackSystemSettingsV1(out)
+			}
 		}
 
-		if !formatOverridden {
-			outputFormat = "text"
+		if semverV2, err := semver.ParseRange(">=0.0.17"); err != nil {
+			logrus.Fatal("Failed to parse SemVer")
+		} else {
+			if semverV2(sv) {
+				displayRollbackSystemSettingsV2(out)
+			}
 		}
-
-		switch strings.ToLower(outputFormat) {
-		case "json":
-			vvData.ToJSON()
-		case "gron":
-			vvData.ToGRON()
-		case "yaml":
-			vvData.ToYAML()
-		case "text", "table":
-			vvData.ToTEXT(noHeaders)
-		}
-
 	},
+}
+
+func displayRollbackSystemSettingsV1(in string) {
+	fmt.Println(in)
+	os.Exit(0)
+}
+
+func displayRollbackSystemSettingsV2(in string) {
+	if strings.ToLower(outputFormat) == "raw" {
+		fmt.Println(in)
+		os.Exit(0)
+	}
+	var vvData objects.VaultVersion
+	marshErr := json.Unmarshal([]byte(in), &vvData)
+	if marshErr != nil {
+		logrus.Fatal("Could not unmarshall data", marshErr)
+	}
+
+	if !formatOverridden {
+		outputFormat = "text"
+	}
+
+	switch strings.ToLower(outputFormat) {
+	case "json":
+		vvData.ToJSON()
+	case "gron":
+		vvData.ToGRON()
+	case "yaml":
+		vvData.ToYAML()
+	case "text", "table":
+		vvData.ToTEXT(noHeaders)
+	}
 }
 
 func rollbackSystemSettings(ver int) (string, error) {

--- a/cmd/tui_functions.go
+++ b/cmd/tui_functions.go
@@ -2,12 +2,101 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/splicemachine/splicectl/cmd/objects"
 )
+
+func promptForCSP() (string, error) {
+
+	cspList := []string{
+		"NONE",
+		"AWS",
+		"AZ",
+		"GCP",
+	}
+
+	// the questions to ask
+	var qs = []*survey.Question{
+		{
+			Name: "cspselect",
+			Prompt: &survey.Select{
+				Message: "Choose a Cloud Service Provider:",
+				Options: cspList,
+			},
+		},
+	}
+	// the answers will be written to this struct
+	answers := struct {
+		CSP string `survey:"cspselect"` // or you can tag fields to match a specific name
+	}{}
+
+	opts := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
+
+	// perform the questions
+	err := survey.Ask(qs, &answers, opts)
+	if err != nil {
+		// logrus.Fatal("No accounts on the list")
+		// // fmt.Println(err.Error())
+		// // return
+		return "", err
+	}
+
+	return answers.CSP, nil
+
+}
+
+func promptForAccountID() (string, error) {
+	out, err := getAccounts()
+	if err != nil {
+		logrus.WithError(err).Error("Error getting Default CR Info")
+		return "", err
+	}
+
+	var accounts objects.AccountList
+
+	marshErr := json.Unmarshal([]byte(out), &accounts)
+	if marshErr != nil {
+		logrus.Fatal("Could not unmarshall data", marshErr)
+	}
+
+	var acctArray []string
+	for _, v := range accounts.Accounts {
+		acctArray = append(acctArray, fmt.Sprintf("%s (%s, %s <%s>)", v.AccountID, v.LastName, v.FirstName, v.EMail))
+	}
+	// the questions to ask
+	var qs = []*survey.Question{
+		{
+			Name: "accountid",
+			Prompt: &survey.Select{
+				Message: "Choose an account:",
+				Options: acctArray,
+			},
+		},
+	}
+	// the answers will be written to this struct
+	answers := struct {
+		AccountID string `survey:"accountid"` // or you can tag fields to match a specific name
+	}{}
+
+	opts := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
+
+	// perform the questions
+	err = survey.Ask(qs, &answers, opts)
+	if err != nil {
+		// logrus.Fatal("No accounts on the list")
+		// // fmt.Println(err.Error())
+		// // return
+		return "", err
+	}
+
+	acctID := strings.TrimSpace(strings.Split(answers.AccountID, "(")[0])
+	return acctID, nil
+}
 
 func promptForDatabaseName() (string, error) {
 	out, err := getDatabaseList()

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -20,6 +20,8 @@ var versionCmd = &cobra.Command{
 		}
 
 		switch strings.ToLower(outputFormat) {
+		case "raw":
+			fmt.Println(versionJSON)
 		case "json":
 			// We want to print the JSON in a condensed format
 			fmt.Println(versionJSON)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,14 +1,12 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/splicemachine/splicectl/cmd/objects"
 )
 
 var versionCmd = &cobra.Command{
@@ -16,25 +14,6 @@ var versionCmd = &cobra.Command{
 	Short:   "Express the 'version' of splicectl.",
 	Aliases: []string{"v"},
 	Run: func(cmd *cobra.Command, args []string) {
-		versionData := objects.Version{}
-		versionJSON := ""
-		if apiServer != "" {
-			version, err := getVersionInfo()
-			if err != nil {
-				logrus.WithError(err).Error("Error getting version info")
-			}
-			clientLine := fmt.Sprintf("\"Client\": {\"SemVer\": \"%s\", \"GitCommit\": \"%s\", \"BuildDate\": \"%s\"},", semVer, gitCommit, buildDate)
-			serverLine := fmt.Sprintf("\"Server\": %s},", version)
-			hostLine := fmt.Sprintf("\"Host\": \"%s\"", apiServer)
-			versionJSON = fmt.Sprintf("{\"VersionInfo\": {\n%s\n%s\n%s\n}", clientLine, serverLine, hostLine)
-		} else {
-			clientLine := fmt.Sprintf("\"Client\": {\"SemVer\": \"%s\", \"GitCommit\": \"%s\", \"BuildDate\": \"%s\"}}", semVer, gitCommit, buildDate)
-			versionJSON = fmt.Sprintf("{\"VersionInfo\": {%s}", clientLine)
-		}
-		marsherr := json.Unmarshal([]byte(versionJSON), &versionData)
-		if marsherr != nil {
-			logrus.WithError(marsherr).Error("Error decoding json for Version")
-		}
 
 		if !formatOverridden {
 			outputFormat = "yaml"
@@ -45,11 +24,11 @@ var versionCmd = &cobra.Command{
 			// We want to print the JSON in a condensed format
 			fmt.Println(versionJSON)
 		case "gron":
-			versionData.ToGRON()
+			versionDetail.ToGRON()
 		case "yaml":
-			versionData.ToYAML()
+			versionDetail.ToYAML()
 		case "text", "table":
-			versionData.ToTEXT(noHeaders)
+			versionDetail.ToTEXT(noHeaders)
 		}
 	},
 }

--- a/cmd/versions_default-cr.go
+++ b/cmd/versions_default-cr.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	"github.com/go-resty/resty/v2"
 	"github.com/sirupsen/logrus"
 
@@ -18,32 +20,64 @@ var versionsDefaultCRCmd = &cobra.Command{
 	splicectl versions default-cr
 `,
 	Run: func(cmd *cobra.Command, args []string) {
+
+		var sv semver.Version
+
+		_, sv = versionDetail.RequirementMet("versions_default-cr")
+
 		out, err := getDefaultCRVersions()
 		if err != nil {
 			logrus.WithError(err).Error("Error getting Default CR Info")
 		}
 
-		crData, cerr := common.RestructureVersions(out)
-		if cerr != nil {
-			logrus.Fatal("Vault Version JSON conversion failed.")
+		if semverV1, err := semver.ParseRange(">=0.0.15 <0.0.17"); err != nil {
+			logrus.Fatal("Failed to parse SemVer")
+		} else {
+			if semverV1(sv) {
+				displayVersionsDefaultCRV1(out)
+			}
 		}
 
-		if !formatOverridden {
-			outputFormat = "text"
+		if semverV2, err := semver.ParseRange(">=0.0.17"); err != nil {
+			logrus.Fatal("Failed to parse SemVer")
+		} else {
+			if semverV2(sv) {
+				displayVersionsDefaultCRV2(out)
+			}
 		}
-
-		switch strings.ToLower(outputFormat) {
-		case "json":
-			crData.ToJSON()
-		case "gron":
-			crData.ToGRON()
-		case "yaml":
-			crData.ToYAML()
-		case "text", "table":
-			crData.ToTEXT(noHeaders)
-		}
-
 	},
+}
+
+func displayVersionsDefaultCRV1(in string) {
+	fmt.Println(in)
+	os.Exit(0)
+}
+
+func displayVersionsDefaultCRV2(in string) {
+	if strings.ToLower(outputFormat) == "raw" {
+		fmt.Println(in)
+		os.Exit(0)
+	}
+	crData, cerr := common.RestructureVersions(in)
+	if cerr != nil {
+		logrus.Fatal("Vault Version JSON conversion failed.")
+	}
+
+	if !formatOverridden {
+		outputFormat = "text"
+	}
+
+	switch strings.ToLower(outputFormat) {
+	case "json":
+		crData.ToJSON()
+	case "gron":
+		crData.ToGRON()
+	case "yaml":
+		crData.ToYAML()
+	case "text", "table":
+		crData.ToTEXT(noHeaders)
+	}
+
 }
 
 func getDefaultCRVersions() (string, error) {


### PR DESCRIPTION
Updated the Create database functionality, added functionality for Pause, Resume, and Delete

## Description

- Updated Commands
  - create splice-database (enhanced options)
  - list database (added clusterId to output)
- Added Commands
  - get accounts (used in create database call)
  - pause 
  - resume
  - delete
- Incidental Updates
  - get database-status (fixed database prompt)
  - get default-cr (removed debugging output)
- Functional Updates
  - Added SemVer checking per command 
  - Display output based on SemVer in order to support old API installations

## Motivation and Context

Customer requests for additional automation features for testing environment provisioning.

## Dependencies

- [Internal PR-654](https://github.com/splicemachine/cloudmgr-ui/pull/654)
  - Adds support for pause/resume/create/delete to the CloudMgr API

## How Has This Been Tested?

Create/Pause/Resume/Delete database handled via splicectl

## Changelog Inclusions

### Additions

- delete database functionality
- Get CloudManager accounts list
- pause database functionality
  * requires cloudmanager api endpoint pauseCluster
- resume database functionality
  * requires cloudmanager api endpoint resumeCluster

### Changes

- create splice-database changed to call cloud manager
  * requires Cloud Manager API to support database/create call
- Moved the SemVer checking to each command function
  * outputs are also driven by the SemVer, output formatting started in v0.0.17 of the API

### Fixes

- removed debugging output
- list database will now prompt for database if not provided

### Deprecated

### Removed

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/splicemachine/splicectl/tree/master/changelog/fragments/00-template.yaml))

  - It is important to include the changelog fragment in your PR, this way the changelog will include the correct PR link.
