### PR TITLE
feat: add support to supply a CA cert for untrusted CA certs

### DIFF
--- a/cmd/apply_cm-settings.go
+++ b/cmd/apply_cm-settings.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -88,6 +90,16 @@ func displayApplyCmSettingsV1(in string) {
 
 func setCMSettings(comp string, in []byte) (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
+
 	uri := fmt.Sprintf("splicectl/v1/vault/cmsettings?component=%s", comp)
 	resp, resperr := restClient.R().
 		SetHeader("X-Token-Bearer", authClient.GetTokenBearer()).

--- a/cmd/apply_database-cr.go
+++ b/cmd/apply_database-cr.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -105,6 +107,16 @@ func displayApplyDatabaseCRV2(in string) {
 
 func setDatabaseCR(dbname string, in []byte) (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
+
 	uri := fmt.Sprintf("splicectl/v1/vault/databasecr?database-name=%s", dbname)
 	resp, resperr := restClient.R().
 		SetHeader("X-Token-Bearer", authClient.GetTokenBearer()).

--- a/cmd/apply_default-cr.go
+++ b/cmd/apply_default-cr.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -95,6 +97,16 @@ func displayApplyDefaultCRV2(in string) {
 
 func setDefaultCR(in []byte) (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
+
 	uri := "splicectl/v1/vault/defaultcr"
 	resp, resperr := restClient.R().
 		SetHeader("X-Token-Bearer", authClient.GetTokenBearer()).

--- a/cmd/apply_image-tag.go
+++ b/cmd/apply_image-tag.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"os"
 
@@ -62,6 +64,16 @@ func displayApplyImageTagV1(in string) {
 
 func setDatabaseImageTag(componentName string, databaseName string, imageTag string) (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
+
 	uri := fmt.Sprintf("splicectl/v1/splicedb/imagetag?component-name=%s&database-name=%s&tag=%s",
 		componentName, databaseName, imageTag)
 	resp, resperr := restClient.R().

--- a/cmd/apply_system-settings.go
+++ b/cmd/apply_system-settings.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -97,6 +99,16 @@ func displayApplySystemSettingsV2(in string) {
 
 func setSystemSettings(in []byte) (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
+
 	uri := "splicectl/v1/vault/systemsettings"
 	resp, resperr := restClient.R().
 		SetHeader("X-Token-Bearer", authClient.GetTokenBearer()).

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 
@@ -63,6 +65,15 @@ var authCmd = &cobra.Command{
 
 func performAuth() (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := "splicectl/v1/auth"
 	resp, resperr := restClient.R().

--- a/cmd/create_splice-database.go
+++ b/cmd/create_splice-database.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -221,6 +223,15 @@ func generateSkel(dbReq *objects.DatabaseRequest) {
 func createSpliceDatabase(dbReq *objects.DatabaseRequest, outputonly bool) (string, error) {
 
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := "splicectl/v1/splicedb/splicedatabase"
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -86,6 +88,15 @@ func getMatchingClusterID(db string) string {
 
 func deleteDatabase(cid string) (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := fmt.Sprintf("splicectl/v1/splicedb/splicedatabasedelete?database-name=%s", cid)
 

--- a/cmd/get_accounts.go
+++ b/cmd/get_accounts.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -76,6 +78,15 @@ func displayGetAccountsV1(in string) {
 
 func getAccounts() (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := "splicectl/v1/cm/accounts"
 	resp, resperr := restClient.R().

--- a/cmd/get_cm-settings.go
+++ b/cmd/get_cm-settings.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -77,6 +79,15 @@ func displayGetCmSettingsV1(in string) {
 
 func getCMSettings(comp string, ver int) (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := fmt.Sprintf("splicectl/v1/vault/cmsettings?component=%s&version=%d", comp, ver)
 	resp, resperr := restClient.R().

--- a/cmd/get_database-cr.go
+++ b/cmd/get_database-cr.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -98,6 +100,15 @@ func displayGetDatabaseV2(in string, fp string) {
 
 func getDatabaseCR(dbname string, ver int) (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := fmt.Sprintf("splicectl/v1/vault/databasecr?version=%d&database-name=%s", ver, dbname)
 	resp, resperr := restClient.R().

--- a/cmd/get_database-status.go
+++ b/cmd/get_database-status.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"os"
 
@@ -54,6 +56,15 @@ func displayGetDatabaseStatusV1(in string) {
 func getDatabaseStatusData(databaseName string) (string, error) {
 
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := fmt.Sprintf("splicectl/v1/splicedb/splicedatabasestatus?database-name=%s", databaseName)
 	resp, resperr := restClient.R().

--- a/cmd/get_image-tag.go
+++ b/cmd/get_image-tag.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -100,6 +102,15 @@ func displayGetImageTagV2(in string) {
 func getImageTagData(componenetName string, databaseName string) (string, error) {
 
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := fmt.Sprintf("splicectl/v1/splicedb/imagetag?component-name=%s&database-name=%s", componenetName, databaseName)
 	resp, resperr := restClient.R().

--- a/cmd/get_vault-key.go
+++ b/cmd/get_vault-key.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"bytes"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -103,6 +105,15 @@ func displayGetVaultKeyV2(in string) {
 
 func getVaultKeyData(keypath string, ver int) (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := fmt.Sprintf("splicectl/v1/vault/vaultkey?version=%d&keypath=%s", ver, keypath)
 	resp, resperr := restClient.R().

--- a/cmd/list_database.go
+++ b/cmd/list_database.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -86,6 +88,15 @@ func displayListDatabaseV2(in string) {
 }
 func getDatabaseList() (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := "splicectl/v1/splicedb/splicedatabase"
 	resp, resperr := restClient.R().

--- a/cmd/pause.go
+++ b/cmd/pause.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -83,6 +85,15 @@ func isDatabaseActive(db string) bool {
 
 func pauseDatabase(db string, msg string) (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := "splicectl/v1/splicedb/splicedatabasepause"
 

--- a/cmd/restart_database.go
+++ b/cmd/restart_database.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -79,6 +81,15 @@ func displayRestartDatabaseV1(in string) {
 
 func restartDatabase(dbname string, force bool) (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := fmt.Sprintf("splicectl/v1/splicedb/splicedatabaserestart?database-name=%s&force=%t", dbname, force)
 	resp, resperr := restClient.R().

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -83,6 +85,15 @@ func isDatabasePaused(db string) bool {
 
 func resumeDatabase(db string, msg string) (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := "splicectl/v1/splicedb/splicedatabaseresume"
 

--- a/cmd/rollback_cm-settings.go
+++ b/cmd/rollback_cm-settings.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -78,6 +80,15 @@ func displayRollbackCmSettingsV1(in string) {
 
 func rollbackCMSettings(comp string, ver int) (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := fmt.Sprintf("splicectl/v1/vault/rollbackcmsettings?component=%s&version=%d", comp, ver)
 	resp, resperr := restClient.R().

--- a/cmd/rollback_database-cr.go
+++ b/cmd/rollback_database-cr.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -93,6 +95,15 @@ func displayRollbackDatabaseCRV2(in string) {
 
 func rollbackDatabaseCR(dbname string, ver int) (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := fmt.Sprintf("splicectl/v1/vault/rollbackdatabasecr?version=%d&database-name=%s", ver, dbname)
 	resp, resperr := restClient.R().

--- a/cmd/rollback_default-cr.go
+++ b/cmd/rollback_default-cr.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -85,6 +87,15 @@ func displayRollbackDefaultCRV2(in string) {
 
 func rollbackDefaultCR(ver int) (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := fmt.Sprintf("splicectl/v1/vault/rollbackdefaultcr?version=%d", ver)
 	resp, resperr := restClient.R().

--- a/cmd/rollback_system-settings.go
+++ b/cmd/rollback_system-settings.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -85,6 +87,15 @@ func displayRollbackSystemSettingsV2(in string) {
 
 func rollbackSystemSettings(ver int) (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := fmt.Sprintf("splicectl/v1/vault/rollbacksystemsettings?version=%d", ver)
 	resp, resperr := restClient.R().

--- a/cmd/rollback_vault-key.go
+++ b/cmd/rollback_vault-key.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -89,6 +91,15 @@ func displayRollbackVaultKeyV2(in string) {
 
 func rollbackVaultKeyData(keypath string, ver int) (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := fmt.Sprintf("splicectl/v1/vault/rollbackvaultkey?version=%d&keypath=%s", ver, keypath)
 	resp, resperr := restClient.R().

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"strings"
 
@@ -37,6 +39,15 @@ var versionCmd = &cobra.Command{
 
 func getVersionInfo() (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := "splicectl"
 	resp, resperr := restClient.R().

--- a/cmd/versions_cm-settings.go
+++ b/cmd/versions_cm-settings.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"os"
 	"strings"
@@ -76,6 +78,15 @@ func displayVersionsCmSettingsV1(in string) {
 
 func getCMSettingsVersions(comp string) (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := fmt.Sprintf("splicectl/v1/vault/cmsettingsversions?component=%s", comp)
 	resp, resperr := restClient.R().

--- a/cmd/versions_database-cr.go
+++ b/cmd/versions_database-cr.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"os"
 	"strings"
@@ -89,6 +91,15 @@ func displayVersionsDatabaseCRV2(in string) {
 
 func getDatabaseCRVersions(db string) (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := fmt.Sprintf("splicectl/v1/vault/databasecrversions?database-name=%s", db)
 	resp, resperr := restClient.R().

--- a/cmd/versions_default-cr.go
+++ b/cmd/versions_default-cr.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"os"
 	"strings"
@@ -82,6 +84,15 @@ func displayVersionsDefaultCRV2(in string) {
 
 func getDefaultCRVersions() (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := "splicectl/v1/vault/defaultcrversions"
 	resp, resperr := restClient.R().

--- a/cmd/versions_system-settings.go
+++ b/cmd/versions_system-settings.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"os"
 	"strings"
@@ -81,6 +83,15 @@ func displayVersionsSystemSettingsV2(in string) {
 
 func getSystemSettingsVersions() (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := "splicectl/v1/vault/systemsettingsversions"
 	resp, resperr := restClient.R().

--- a/cmd/versions_vault-key.go
+++ b/cmd/versions_vault-key.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"os"
 	"strings"
@@ -85,6 +87,15 @@ func displayVersionsVaultKeyV2(in string) {
 
 func getVaultKeyVersionData(keypath string) (string, error) {
 	restClient := resty.New()
+	// Check if we've set a caBundle (via --ca-cert parameter)
+	if len(caBundle) > 0 {
+		roots := x509.NewCertPool()
+		ok := roots.AppendCertsFromPEM([]byte(caBundle))
+		if !ok {
+			logrus.Info("Failed to parse CABundle")
+		}
+		restClient.SetTLSClientConfig(&tls.Config{RootCAs: roots})
+	}
 
 	uri := fmt.Sprintf("splicectl/v1/vault/vaultkeyversions?keypath=%s", keypath)
 	resp, resperr := restClient.R().


### PR DESCRIPTION
## Description

Provide a mechanism to supply a CA certificate to use in validation of the SSL endpoint for splicectl-api.  This allows use of self-signed certs or certs that are signed by an untrusted CA.

The primary work is done in main.go.  Reading from --cacert and SPLICECTL_CACERT.  The rest of the edits are all the same, consuming the caBundle set in main.go and passing it to the goresty object.

## Motivation and Context

In many on-prem installation we may not have a CA issued for POC and need a way to handle self-signed certificates.

## Dependencies


## How Has This Been Tested?

The functionality remains exactly the same if `--cacert` or `export SPLICECTL_CACERT=` are not specified or set.

## Screenshots (if appropriate)

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [x] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

### Additions

- added --cacert /path/to/cert.crt to pass in a certificate used as the CA to validate SSL connections
- added support to read from SPLICECTL_CACERT=/path/to/cert.crt to auto-set the --cacert option.

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes

