### PR TITLE
Added option for "op" as cloud provider.

### DIFF
--- a/cmd/create_splice-database.go
+++ b/cmd/create_splice-database.go
@@ -36,7 +36,7 @@ var createSpliceDatabaseCmd = &cobra.Command{
 	While you can specify each of the parameters on the command line, it is much
 	easier to create a SKEL yaml file and use that to create the database.
 
-	splicectl create splice-database --skel --account-id <accountid> --cloud-provider <aws|az|gcp|none> > ~/tmp/splicedb-create.yaml
+	splicectl create splice-database --skel --account-id <accountid> --cloud-provider <aws|az|gcp|op|none> > ~/tmp/splicedb-create.yaml
 	# edit the ~/tmp/splicedb-create.yaml
 	splicectl create splice-database --file ~/tmp/splicedb-create.yaml`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -158,7 +158,7 @@ func populateRequest(cmd *cobra.Command, req *objects.DatabaseRequest, fileData 
 		if len(req.CloudProvider) == 0 || !fileData {
 			selectedCSP, err := promptForCSP()
 			if err != nil {
-				requiredList = append(requiredList, "--cloud-provider, (aws|az|gcp|none)")
+				requiredList = append(requiredList, "--cloud-provider, (aws|az|gcp|op|none)")
 			}
 			req.CloudProvider = selectedCSP
 		}
@@ -272,7 +272,7 @@ func init() {
 	createSpliceDatabaseCmd.Flags().Int("backup-interval", 1, "Specify the Backup Interval (default=1)")
 	createSpliceDatabaseCmd.Flags().Int("keep-backups", 1, "Specify the Backup Keep Count (default=1)")
 	createSpliceDatabaseCmd.Flags().String("backup-start-window", "02:30", "Specify the Backup Start Window (default=02:30)")
-	createSpliceDatabaseCmd.Flags().String("cloud-provider", "", "Specify the Cloud Provider (az|aws|gcp|none)")
+	createSpliceDatabaseCmd.Flags().String("cloud-provider", "", "Specify the Cloud Provider (az|aws|gcp|op|none)")
 	createSpliceDatabaseCmd.Flags().Int("spark-executors", 4, "Specify the number of Spark Executors/OLAP (default=4)")
 	createSpliceDatabaseCmd.Flags().Int("region-servers", 4, "Specify the number of Region Servers/OLTP (default=4)")
 	createSpliceDatabaseCmd.Flags().Bool("dedicated-storage", false, "Specify if dedicated storage should be used")

--- a/cmd/tui_functions.go
+++ b/cmd/tui_functions.go
@@ -15,6 +15,7 @@ func promptForCSP() (string, error) {
 
 	cspList := []string{
 		"NONE",
+		"OP",
 		"AWS",
 		"AZ",
 		"GCP",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Added an option to provide "op" as a provider in addition to"aws"|"gcp"|"az" when supplying cloud provider to splicectl cli.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

- When deploying to an environment that is not in one of the three major clouds, there needed to be another option for cloud provider.
- This change reflects the changes made to the splicectl/api with regard to the CLOUD_PROVIDER option. See [splicectl/api changes](https://github.com/splicemachine/dbaas-infrastructure/pull/1720)
<!-- If it fixes an open issue, please link to the issue here. -->
See [DBAAS-5592](https://splicemachine.atlassian.net/browse/DBAAS-5592?atlOrigin=eyJpIjoiMDhjNTEyMjhhZWY1NGEwZWIwMzQ2OTgyMDFkZTg5N2UiLCJwIjoiaiJ9)

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [ ] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->

<!-- Please list your changes as bullets under appropriate section heading(s) -->
### Additions

- Added "op" as a valid option for cloud-provider.

## Dependencies
<!-- If this fix is dependent on code in other repos to be deployed, list that here. -->

Dependent on [spliceclt/api](https://github.com/splicemachine/dbaas-infrastructure/pull/1720).

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->

- Tests were carried out on the splicectl/api side, new string option should work without issue.

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
