### PR TITLE
Add a check around default-cr (apply) to check to ensure the JSON is properly embedded in a "data" named element.

### DIFF
--- a/cmd/apply_default-cr.go
+++ b/cmd/apply_default-cr.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -14,6 +15,44 @@ import (
 	"github.com/splicemachine/splicectl/cmd/objects"
 	"github.com/splicemachine/splicectl/common"
 )
+
+const dataKey = "data"
+
+var (
+	noTopLevelDataError   = errors.New("Default CR did not contain top level 'data' element that is required")
+	dataIsWrongTypeError  = errors.New("data element in Default CR is not an object, but should be")
+	doubleNestedDataError = errors.New("Default CR appears to contain a second level 'data' element, your Default CR appears to be double nested")
+)
+
+// validateDefaultCR - validate that the data representing default-cr contains a top
+// level field named 'data'.
+func validateDefaultCR(defaultCR []byte) (interface{}, error) {
+	// get map representation of Default CR
+	crMap := make(map[string]interface{})
+	if err := json.Unmarshal(defaultCR, &crMap); err != nil {
+		return nil, err
+	}
+
+	// get the data element of the Default CR
+	crData, ok := crMap[dataKey]
+	if !ok {
+		return crMap, noTopLevelDataError
+	}
+
+	// verify that the data element is a map
+	crDataMap, ok := crData.(map[string]interface{})
+	if !ok {
+		return crMap, dataIsWrongTypeError
+	}
+
+	// verify that there is not a data element in the top level data element,
+	// would imply double nesting of Default CR
+	if _, ok := crDataMap[dataKey]; ok {
+		return crData, doubleNestedDataError
+	}
+
+	return crMap, nil
+}
 
 var applyDefaultCRCmd = &cobra.Command{
 	Use:   "default-cr",
@@ -35,6 +74,9 @@ var applyDefaultCRCmd = &cobra.Command{
 		jsonBytes, cerr := common.WantJSON(fileBytes)
 		if cerr != nil {
 			logrus.Fatal("The input data MUST be in either JSON or YAML format")
+		}
+		if _, err := validateDefaultCR(jsonBytes); err != nil {
+			logrus.WithError(err).Fatal("Error validating Default CR")
 		}
 
 		out, err := setDefaultCR(jsonBytes)

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import "testing"
+
+const (
+	validDefaultCR       = `{"data":{"key":"value"}}`
+	invalidJSON          = `this is invalid json`
+	noTopLevelDataJSON   = `{"key":"value"}`
+	dataIsWrongTypeJSON  = `{"data":"not a map"}`
+	doubleNestedDataJSON = `{"data":{"data":"this data is double nested"}}`
+)
+
+func TestValidateDefaultCR(t *testing.T) {
+	if _, err := validateDefaultCR([]byte(validDefaultCR)); err != nil {
+		t.Fatalf("Expected to get no error with validDefaultCR, instead got: %v", err)
+	}
+	if _, err := validateDefaultCR([]byte(invalidJSON)); err == nil {
+		t.Fatalf("Expected to get an error with invalidJSON, but got none.")
+	}
+	if _, err := validateDefaultCR([]byte(noTopLevelDataJSON)); err == nil {
+		t.Fatalf("Expected to get an error with noTopLevelDataJSON, but got none.")
+	}
+	if _, err := validateDefaultCR([]byte(dataIsWrongTypeJSON)); err == nil {
+		t.Fatalf("Expected to get an error with dataIsWrongTypeJSON, but got none.")
+	}
+	if _, err := validateDefaultCR([]byte(doubleNestedDataJSON)); err == nil {
+		t.Fatalf("Expected to get an error with doubleNestedDataJSON, but got none.")
+	}
+}


### PR DESCRIPTION
<!--
- Rebase your branch on the latest upstream master
- If this PR contains user facing change, please follow the checklist
- Provide a general summary of your changes in the Title above
-->

## Description
<!--- Describe your changes in detail -->

Added a validation around user input to the `splicectl apply default-cr` command. The input specified by --file will now be validated for a top level 'data' element. No actual validation of the contents of the data element occurs, only the verification that it exists and that there is no 'data' element as its immediate child, which would likely indicate an accidental double nesting of the default-cr.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This will prevent the passing of some potentially invalid default-crs to the splicectl/api and serve as an early warning that the input file is invalid. Specific errors are returned based on what splicectl is able to identify is wrong with the input, which should help users be able to quickly identify and fix their issue.

See [DBAAS-5601](https://splicemachine.atlassian.net/browse/DBAAS-5601?atlOrigin=eyJpIjoiNWU3ZmUzNzdkZDI3NGI0Yjg2M2I0ODdhZjkwM2Y5YzIiLCJwIjoiaiJ9)

<!--- If it fixes an open issue, please link to the issue here. -->

## Dependencies
<!--- If this fix is dependent on code in other repos to be deployed, list that here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

A test case for each unique type of error that is to be expected has been created and exists in the apply_test.TestValidateDefaultCR() function. I also manually tested this with the splicectl tool on a live db as well and get the expected errors when providing invalid inputs.

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [ ] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

### Changes

--file input for the `splicectl apply default-cr` command is now partially validated before being sent to the splicectl/api.

## Checklist
