### PR TITLE
K8s: splicectl - Add a `-a/—active` and `-p/—paused` to `list database` command

### DIFF
--- a/cmd/apply_default-cr.go
+++ b/cmd/apply_default-cr.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -14,6 +15,44 @@ import (
 	"github.com/splicemachine/splicectl/cmd/objects"
 	"github.com/splicemachine/splicectl/common"
 )
+
+const dataKey = "data"
+
+var (
+	noTopLevelDataError   = errors.New("Default CR did not contain top level 'data' element that is required")
+	dataIsWrongTypeError  = errors.New("data element in Default CR is not an object, but should be")
+	doubleNestedDataError = errors.New("Default CR appears to contain a second level 'data' element, your Default CR appears to be double nested")
+)
+
+// validateDefaultCR - validate that the data representing default-cr contains a top
+// level field named 'data'.
+func validateDefaultCR(defaultCR []byte) (interface{}, error) {
+	// get map representation of Default CR
+	crMap := make(map[string]interface{})
+	if err := json.Unmarshal(defaultCR, &crMap); err != nil {
+		return nil, err
+	}
+
+	// get the data element of the Default CR
+	crData, ok := crMap[dataKey]
+	if !ok {
+		return crMap, noTopLevelDataError
+	}
+
+	// verify that the data element is a map
+	crDataMap, ok := crData.(map[string]interface{})
+	if !ok {
+		return crMap, dataIsWrongTypeError
+	}
+
+	// verify that there is not a data element in the top level data element,
+	// would imply double nesting of Default CR
+	if _, ok := crDataMap[dataKey]; ok {
+		return crData, doubleNestedDataError
+	}
+
+	return crMap, nil
+}
 
 var applyDefaultCRCmd = &cobra.Command{
 	Use:   "default-cr",
@@ -35,6 +74,9 @@ var applyDefaultCRCmd = &cobra.Command{
 		jsonBytes, cerr := common.WantJSON(fileBytes)
 		if cerr != nil {
 			logrus.Fatal("The input data MUST be in either JSON or YAML format")
+		}
+		if _, err := validateDefaultCR(jsonBytes); err != nil {
+			logrus.WithError(err).Fatal("Error validating Default CR")
 		}
 
 		out, err := setDefaultCR(jsonBytes)

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import "testing"
+
+const (
+	validDefaultCR       = `{"data":{"key":"value"}}`
+	invalidJSON          = `this is invalid json`
+	noTopLevelDataJSON   = `{"key":"value"}`
+	dataIsWrongTypeJSON  = `{"data":"not a map"}`
+	doubleNestedDataJSON = `{"data":{"data":"this data is double nested"}}`
+)
+
+func TestValidateDefaultCR(t *testing.T) {
+	if _, err := validateDefaultCR([]byte(validDefaultCR)); err != nil {
+		t.Fatalf("Expected to get no error with validDefaultCR, instead got: %v", err)
+	}
+	if _, err := validateDefaultCR([]byte(invalidJSON)); err == nil {
+		t.Fatalf("Expected to get an error with invalidJSON, but got none.")
+	}
+	if _, err := validateDefaultCR([]byte(noTopLevelDataJSON)); err == nil {
+		t.Fatalf("Expected to get an error with noTopLevelDataJSON, but got none.")
+	}
+	if _, err := validateDefaultCR([]byte(dataIsWrongTypeJSON)); err == nil {
+		t.Fatalf("Expected to get an error with dataIsWrongTypeJSON, but got none.")
+	}
+	if _, err := validateDefaultCR([]byte(doubleNestedDataJSON)); err == nil {
+		t.Fatalf("Expected to get an error with doubleNestedDataJSON, but got none.")
+	}
+}

--- a/cmd/list_database.go
+++ b/cmd/list_database.go
@@ -27,8 +27,19 @@ var listDatabaseCmd = &cobra.Command{
 
 		_, sv = versionDetail.RequirementMet("list_database")
 
+		// check active and paused flag values
+		active, err := cmd.Flags().GetBool("active")
+		if err != nil {
+			logrus.WithError(err).Error("Error getting Database CR Info")
+		}
+
+		paused, err := cmd.Flags().GetBool("paused")
+		if err != nil {
+			logrus.WithError(err).Error("Error getting Database CR Info")
+		}
+
 		// databaseName, _ := cmd.Flags().GetString("database-name")
-		out, err := getDatabaseList()
+		out, err := getDatabaseListWithFlags(active, paused)
 		if err != nil {
 			logrus.WithError(err).Error("Error getting Database CR Info")
 		}
@@ -84,7 +95,16 @@ func displayListDatabaseV2(in string) {
 	}
 
 }
+
+// getDatabaseList - simple wrapper around getDatabaseListWithFlags to prevent
+// cascading issues with change in API.
 func getDatabaseList() (string, error) {
+	return getDatabaseListWithFlags(false, false)
+}
+
+// getDatabaseListWithFlags - gets list of databases and filters/orders them
+// based on flags.
+func getDatabaseListWithFlags(active, paused bool) (string, error) {
 	restClient := resty.New()
 
 	uri := "splicectl/v1/splicedb/splicedatabase"
@@ -100,13 +120,21 @@ func getDatabaseList() (string, error) {
 		return "", resperr
 	}
 
-	return string(resp.Body()[:]), nil
+	// filter and order DBList returned from api call
+	rawRespBody, dbList := resp.Body()[:], &objects.DatabaseList{}
+	if err := json.Unmarshal(rawRespBody, dbList); err != nil {
+		return "", err
+	}
+	dbList = dbList.FilterByStatus(active, paused)
+	filteredDBList, err := json.Marshal(dbList)
+	// TODO: return either bytes or json, do not go back to strings
+	return string(filteredDBList), err
 
 }
 
 func init() {
 	listCmd.AddCommand(listDatabaseCmd)
 
-	// getDatabaseCRCmd.Flags().String("database-name", "", "Specify the database name")
-
+	listDatabaseCmd.Flags().BoolP("active", "a", false, "Select if you want to get active databases.")
+	listDatabaseCmd.Flags().BoolP("paused", "p", false, "Select if you want to get paused databases.")
 }


### PR DESCRIPTION
<!--
- Rebase your branch on the latest upstream master
- If this PR contains user facing change, please follow the checklist
- Provide a general summary of your changes in the Title above
-->

## Description
<!--- Describe your changes in detail -->

I added a new set of flags to the `list database` command that when used either only get all active, all paused, or group by status the resulting list of databases that are returned by the command.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Makes it easier to view databases based on status.

See [DBAAS-5328](https://splicemachine.atlassian.net/browse/DBAAS-5328?atlOrigin=eyJpIjoiOWMxYWIxZDU4Mjg3NDkzNDk2MDBiMjE3MjA4NDE5NzAiLCJwIjoiaiJ9)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

These changes were manually tested against a couple of live running databases with some being paused and others active.

List command with any combination of flags worked as expected.

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [ ] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

- Added -a/--active and -p/--paused flags to the `list database` command. 
  - If neither flag is used then all databases in their original order will be displayed.
  - If -a/--active is used then only active databases will be listed.
  - If -p/--paused is used then only paused databases will be listed.
  - If both are used then all databases will be listed with active databases listed first in a group and then all paused databases following them.

## Checklist