### PR TITLE
K8s: splicectl - Add a cmd.ChangeLog variable, and set it with the contents of the most recent changelog text

### DIFF
--- a/cmd/changelog.go
+++ b/cmd/changelog.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/go-resty/resty/v2"
@@ -16,14 +17,22 @@ var changelogCmd = &cobra.Command{
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		// TODO: output the changelog var...
-		logrus.Info(versionDetail.VersionInfo.Client.SemVer)
-		url := fmt.Sprintf("https://api.github.com/repos/splicemachine/splicectl/releases/tags/%s", versionDetail.VersionInfo.Client.SemVer)
+		_, semVerNum := ClientSemVer()
+		url := fmt.Sprintf("https://api.github.com/repos/splicemachine/splicectl/releases/tags/%s", semVerNum)
 		client := resty.New()
 		resp, err := client.R().Get(url)
 		if err != nil {
 			logrus.WithError(err).Fatal("request could not be completed due to error, changelog is retrieved through api call to Github that requires internet access")
 		}
-		logrus.Info(string(resp.Body()))
+		jsonMap := make(map[string]interface{})
+		if err := json.Unmarshal(resp.Body(), &jsonMap); err != nil {
+			logrus.WithError(err).Fatal("could not get changelog, recieved error while parsing gh api response")
+		}
+		if _, ok := jsonMap["body"]; !ok {
+			logrus.Fatal("an unexpected response was returned from the Github api, the changelog cannot be found")
+		}
+		// using fmt here instead of logrus/log in order to get rid of leading [INFO] or similar header
+		fmt.Println(jsonMap["body"])
 	},
 }
 

--- a/cmd/changelog.go
+++ b/cmd/changelog.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var changelogCmd = &cobra.Command{
+	Use:   "changelog",
+	Short: "List the most recent changes on the changelog for splicectl.",
+	Long: `EXAMPLES
+	splicectl changelog
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// TODO: output the changelog var...
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(changelogCmd)
+}

--- a/cmd/changelog.go
+++ b/cmd/changelog.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"fmt"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -12,6 +16,14 @@ var changelogCmd = &cobra.Command{
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		// TODO: output the changelog var...
+		logrus.Info(versionDetail.VersionInfo.Client.SemVer)
+		url := fmt.Sprintf("https://api.github.com/repos/splicemachine/splicectl/releases/tags/%s", versionDetail.VersionInfo.Client.SemVer)
+		client := resty.New()
+		resp, err := client.R().Get(url)
+		if err != nil {
+			logrus.WithError(err).Fatal("request could not be completed due to error, changelog is retrieved through api call to Github that requires internet access")
+		}
+		logrus.Info(string(resp.Body()))
 	},
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -25,6 +26,9 @@ var (
 	versionJSON   string
 	cfgFile       string
 	serverURI     string
+
+	// semVerReg - gets the semVer portion only, cutting off any other release details
+	semVerReg = regexp.MustCompile(`(v[0-9]+\.[0-9]+\.[0-9]+).*`)
 )
 
 // var sessionID string
@@ -188,4 +192,16 @@ func createRestrictedConfigFile(fileName string) {
 			}
 		}
 	}
+}
+
+// ClientSemVer - returns the full semVer as the first string and the numerical
+// portion as the second string, they may be identical. One example where they
+// would not be is:
+//         semVer: v0.1.1-cacert -> (v0.1.1-cacert, v0.1.1).
+func ClientSemVer() (string, string) {
+	submatches := semVerReg.FindStringSubmatch(semVer)
+	if submatches == nil || len(submatches) < 2 {
+		logrus.Fatalf("the semver in the current build is not valid: %s", semVer)
+	}
+	return submatches[0], submatches[1]
 }


### PR DESCRIPTION
<!--
- Rebase your branch on the latest upstream master
- If this PR contains user facing change, please follow the checklist
- Provide a general summary of your changes in the Title above
-->

## Description
<!--- Describe your changes in detail -->

Added a changelog command that output the changelog based on the client semantic version of the splicectl client. This works by making an api call to Github requesting the changelog based on the version and thus requires an internet connection to work.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This will help when a new version is released, so that anybody who is familiar with the splicectl tool will be able to view the changes to the tool and use some of the new available commands or learn the ways as well as update their current usage based on any breaking changes to the existing commands.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested the url in the api call returned what was expected and it did, but only when supplied with a specific format for the semantic version which the splicectl versions do not always match. Therefore, I made and tested a regex to parse out the important part of the version. I then built the app with different versions and all worked as expected.

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [ ] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

### Additions

- changelog command can now be used like so: `splicectl changelog`. It will display the markdown content of the changelog for the version of splicectl that you are using.

## Checklist
