### PR TITLE
K8s: splicectl - In the commands that use --database-name, alias both --database and --workspace

### DIFF
--- a/cmd/apply_database-cr.go
+++ b/cmd/apply_database-cr.go
@@ -20,7 +20,7 @@ var applyDatabaseCRCmd = &cobra.Command{
 	Use:   "database-cr",
 	Short: "Submit a new CR for a specified database in the cluster.",
 	Long: `EXAMPLES
-	splicectl list database
+	splicectl list workspace
     splicectl get database-cr --database-name splicedb -o json > ~/tmp/splicedb.json
     # edit the file
     splicectl apply database-cr --database-name splicedb --file ~/tmp/splicedb.json
@@ -38,7 +38,7 @@ var applyDatabaseCRCmd = &cobra.Command{
 
 		_, sv = versionDetail.RequirementMet("apply_database-cr")
 
-		databaseName, _ := cmd.Flags().GetString("database-name")
+		databaseName := common.DatabaseName(cmd)
 		if len(databaseName) == 0 {
 			databaseName, dberr = promptForDatabaseName()
 			if dberr != nil {

--- a/cmd/apply_database-cr.go
+++ b/cmd/apply_database-cr.go
@@ -24,6 +24,13 @@ var applyDatabaseCRCmd = &cobra.Command{
     splicectl get database-cr --database-name splicedb -o json > ~/tmp/splicedb.json
     # edit the file
     splicectl apply database-cr --database-name splicedb --file ~/tmp/splicedb.json
+
+	Note: --database-name and -d are the preferred way to supply the database name.
+	However, --database and --workspace can also be used as well. In the event that
+	more than one of them is supplied database-name and d are preferred over all
+	and workspace is preferred over database. The most preferred option that is
+	supplied will be used and a message will be displayed letting you know which
+	option was chosen if more than one were supplied.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		var dberr error
@@ -126,7 +133,11 @@ func setDatabaseCR(dbname string, in []byte) (string, error) {
 func init() {
 	applyCmd.AddCommand(applyDatabaseCRCmd)
 
+	// add database name and aliases
 	applyDatabaseCRCmd.Flags().StringP("database-name", "d", "", "Specify the database name")
+	applyDatabaseCRCmd.Flags().String("database", "", "Alias for database-name, prefer the use of -d and --database-name.")
+	applyDatabaseCRCmd.Flags().String("workspace", "", "Alias for database-name, prefer the use of -d and --database-name.")
+
 	applyDatabaseCRCmd.Flags().StringP("file", "f", "", "Specify the input file")
 	// applyDatabaseCRCmd.MarkFlagRequired("database-name")
 	applyDatabaseCRCmd.MarkFlagRequired("file")

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -9,7 +9,7 @@ var createCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	Short: "Create cluster resources",
 	Long: `EXAMPLES
-	splicectl create splice-database --database-name splicedb --dnsprefix splicedb`,
+	splicectl create workspace --database-name splicedb --dnsprefix splicedb`,
 	Run: func(cmd *cobra.Command, args []string) {},
 }
 

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -10,17 +10,25 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/splicemachine/splicectl/cmd/objects"
+	"github.com/splicemachine/splicectl/common"
 )
 
 var deleteCmd = &cobra.Command{
 	Use:   "delete",
 	Args:  cobra.MinimumNArgs(0),
-	Short: "Delete Cluster Databases",
+	Short: "Delete Cluster workspaces",
 	Long: `EXAMPLES
-	splicectl list databases
+	splicectl list workspace
 	splicectl delete --database-name <database> --delete
 
-	  * The '--delete' is required as a validation for the deletion request`,
+	* The '--delete' is required as a validation for the deletion request
+	  
+	Note: --database-name and -d are the preferred way to supply the database name.
+	However, --database and --workspace can also be used as well. In the event that
+	more than one of them is supplied database-name and d are preferred over all
+	and workspace is preferred over database. The most preferred option that is
+	supplied will be used and a message will be displayed letting you know which
+	option was chosen if more than one were supplied. `,
 	Run: func(cmd *cobra.Command, args []string) {
 		var dberr error
 		var sv semver.Version
@@ -28,11 +36,11 @@ var deleteCmd = &cobra.Command{
 		_, sv = versionDetail.RequirementMet("delete")
 
 		verifyDelete, _ := cmd.Flags().GetBool("delete")
-		databaseName, _ := cmd.Flags().GetString("database-name")
+		databaseName := common.DatabaseName(cmd)
 		if len(databaseName) == 0 {
 			databaseName, dberr = promptForDatabaseName()
 			if dberr != nil {
-				logrus.Fatal("Could not get a list of Databases", dberr)
+				logrus.Fatal("Could not get a list of workspaces", dberr)
 			}
 		}
 		if verifyDelete {
@@ -40,7 +48,7 @@ var deleteCmd = &cobra.Command{
 			if len(clusterID) > 0 {
 				out, err := deleteDatabase(clusterID)
 				if err != nil {
-					logrus.Warn("Deleting database failed.")
+					logrus.Warn("Deleting workspace failed.")
 				}
 				if semverV1, err := semver.ParseRange(">=0.1.7"); err != nil {
 					logrus.Fatal("Failed to parse SemVer")
@@ -50,7 +58,7 @@ var deleteCmd = &cobra.Command{
 					}
 				}
 			} else {
-				logrus.Fatal("Unable to determine ClusterId from Database Name")
+				logrus.Fatal("Unable to determine ClusterId from workspace Name")
 			}
 		} else {
 			logrus.Fatal("You MUST specify --delete on the commandline to validate the deletion")
@@ -72,7 +80,7 @@ func getMatchingClusterID(db string) string {
 
 	marshErr := json.Unmarshal([]byte(dbJSON), &dbList)
 	if marshErr != nil {
-		logrus.Fatal("Could not unmarshall database list for ClusterId", marshErr)
+		logrus.Fatal("Could not unmarshall workspace list for ClusterId", marshErr)
 	}
 
 	for _, v := range dbList.Clusters {
@@ -109,6 +117,11 @@ func deleteDatabase(cid string) (string, error) {
 
 func init() {
 	rootCmd.AddCommand(deleteCmd)
-	deleteCmd.Flags().StringP("database-name", "d", "", "Specify the Splice Machine Database to Pause")
+
+	// add database name and aliases
+	deleteCmd.Flags().StringP("database-name", "d", "", "Specify the database name")
+	deleteCmd.Flags().String("database", "", "Alias for database-name, prefer the use of -d and --database-name.")
+	deleteCmd.Flags().String("workspace", "", "Alias for database-name, prefer the use of -d and --database-name.")
+
 	deleteCmd.Flags().Bool("delete", false, "Verification parameter to perform the deletion")
 }

--- a/cmd/get_database-status.go
+++ b/cmd/get_database-status.go
@@ -7,6 +7,7 @@ import (
 	"github.com/blang/semver/v4"
 	"github.com/go-resty/resty/v2"
 	"github.com/sirupsen/logrus"
+	"github.com/splicemachine/splicectl/common"
 
 	"github.com/spf13/cobra"
 )
@@ -16,6 +17,13 @@ var getDatabaseStatus = &cobra.Command{
 	Short: "Get the status of database.",
 	Long: `EXAMPLES
 	splicectl get database-status --database-name "test"
+
+	Note: --database-name and -d are the preferred way to supply the database name.
+	However, --database and --workspace can also be used as well. In the event that
+	more than one of them is supplied database-name and d are preferred over all
+	and workspace is preferred over database. The most preferred option that is
+	supplied will be used and a message will be displayed letting you know which
+	option was chosen if more than one were supplied.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		var dberr error
@@ -23,7 +31,7 @@ var getDatabaseStatus = &cobra.Command{
 
 		_, sv = versionDetail.RequirementMet("get_database-status")
 
-		databaseName, _ := cmd.Flags().GetString("database-name")
+		databaseName := common.DatabaseName(cmd)
 		if len(databaseName) == 0 {
 			databaseName, dberr = promptForDatabaseName()
 			if dberr != nil {
@@ -72,5 +80,9 @@ func getDatabaseStatusData(databaseName string) (string, error) {
 
 func init() {
 	getCmd.AddCommand(getDatabaseStatus)
+
+	// add database name and aliases
 	getDatabaseStatus.Flags().StringP("database-name", "d", "", "Specify the database name")
+	getDatabaseStatus.Flags().String("database", "", "Alias for database-name, prefer the use of -d and --database-name.")
+	getDatabaseStatus.Flags().String("workspace", "", "Alias for database-name, prefer the use of -d and --database-name.")
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -7,9 +7,9 @@ import (
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Args:  cobra.MinimumNArgs(1),
-	Short: "List resources in the Splice Machine Database Cluster",
+	Short: "List resources in the Splice Machine workspace Cluster",
 	Long: `EXAMPLES
-	splicectl list database`,
+	splicectl list workspace`,
 	Run: func(cmd *cobra.Command, args []string) {},
 }
 

--- a/cmd/list_database.go
+++ b/cmd/list_database.go
@@ -15,11 +15,11 @@ import (
 )
 
 var listDatabaseCmd = &cobra.Command{
-	Use:     "database",
-	Aliases: []string{"databases"},
+	Use:     "workspace",
+	Aliases: []string{"workspaces", "database", "databases"},
 	Short:   "Retrieve a list of splice databases in the cluster.",
 	Long: `EXAMPLES
-	splicectl list database
+	splicectl list workspace
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 

--- a/cmd/objects/version.go
+++ b/cmd/objects/version.go
@@ -25,7 +25,7 @@ var CommandVersions = map[string]string{
 	"apply_image-tag":          "0.0.16",
 	"apply_system-settings":    "0.0.14",
 	"apply_vault-key":          "0.0.14",
-	"create_splice-database":   "0.1.7",
+	"create_database":          "0.1.7",
 	"delete":                   "0.1.7",
 	"get_accounts":             "0.1.7",
 	"get_cm-settings":          "0.1.6",

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -9,7 +9,7 @@ var restartCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	Short: "Restart components of the Splice DB Cluster",
 	Long: `EXAMPLES
-	splicectl restart database --database-name <dbname>`,
+	splicectl restart workspace --database-name <dbname>`,
 	Run: func(cmd *cobra.Command, args []string) {},
 }
 

--- a/cmd/restart_database.go
+++ b/cmd/restart_database.go
@@ -10,16 +10,25 @@ import (
 	"github.com/go-resty/resty/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/splicemachine/splicectl/cmd/objects"
+	"github.com/splicemachine/splicectl/common"
 
 	"github.com/spf13/cobra"
 )
 
 var restartDatabaseCmd = &cobra.Command{
-	Use:   "database",
-	Short: "Restart a specific database in the Splice DB Cluster.",
+	Use:     "workspace",
+	Aliases: []string{"database"},
+	Short:   "Restart a specific database in the Splice DB Cluster.",
 	Long: `EXAMPLES
-	splicectl list database
-	splicectl restart database --database-name splicedb
+	splicectl list workspace
+	splicectl restart workspace --database-name splicedb
+
+	Note: --database-name and -d are the preferred way to supply the database name.
+	However, --database and --workspace can also be used as well. In the event that
+	more than one of them is supplied database-name and d are preferred over all
+	and workspace is preferred over database. The most preferred option that is
+	supplied will be used and a message will be displayed letting you know which
+	option was chosen if more than one were supplied.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		var dberr error
@@ -27,7 +36,7 @@ var restartDatabaseCmd = &cobra.Command{
 
 		_, sv = versionDetail.RequirementMet("restart_database")
 
-		databaseName, _ := cmd.Flags().GetString("database-name")
+		databaseName := common.DatabaseName(cmd)
 		forceRestart, _ := cmd.Flags().GetBool("force")
 		if len(databaseName) == 0 {
 			databaseName, dberr = promptForDatabaseName()
@@ -100,7 +109,11 @@ func restartDatabase(dbname string, force bool) (string, error) {
 func init() {
 	restartCmd.AddCommand(restartDatabaseCmd)
 
+	// add database name and aliases
 	restartDatabaseCmd.Flags().StringP("database-name", "d", "", "Specify the database name")
+	restartDatabaseCmd.Flags().String("database", "", "Alias for database-name, prefer the use of -d and --database-name.")
+	restartDatabaseCmd.Flags().String("workspace", "", "Alias for database-name, prefer the use of -d and --database-name.")
+
 	restartDatabaseCmd.Flags().BoolP("force", "f", false, "Force the restart")
 
 }

--- a/cmd/versions.go
+++ b/cmd/versions.go
@@ -11,7 +11,7 @@ var versionsCmd = &cobra.Command{
 	Long: `EXAMPLES
 	splicectl versions system-settings
 	splicectl versions default-cr
-	splicectl list database
+	splicectl list workspace
 	splicectl versions database-cr --database-name splicedb
 	`,
 	Run: func(cmd *cobra.Command, args []string) {},

--- a/common/functions.go
+++ b/common/functions.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/spf13/cobra"
 	"github.com/splicemachine/splicectl/cmd/objects"
 	"sigs.k8s.io/yaml"
 )
@@ -68,4 +69,11 @@ func RestructureVersions(in string) (objects.VaultVersionList, error) {
 	}
 
 	return crData, nil
+}
+
+// DatabaseName - gets the most preferred database name from the command flags.
+// This is meant to be used to pick the best option when multiple flags are
+// provided for the database-name through its different aliases.
+func DatabaseName(cmd *cobra.Command) (string, string) {
+	return "", ""
 }

--- a/common/functions_test.go
+++ b/common/functions_test.go
@@ -1,0 +1,61 @@
+package common
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func TestNoDatabaseName(t *testing.T) {
+	tcmd := &cobra.Command{
+		Use: "test",
+		Run: func(cmd *cobra.Command, args []string) {
+			name := DatabaseName(cmd)
+			if name != "" {
+				t.Fatalf("there should have been no database name, but instead found: %s", name)
+			}
+		},
+	}
+	tcmd.SetArgs([]string{})
+	if err := tcmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDatabaseName(t *testing.T) {
+	for _, args := range [][]string{
+		{"-d", "splicedb"},
+		{"--database-name", "splicedb"},
+		{"--workspace", "splicedb"},
+		{"--database", "splicedb"},
+		{"--database-name", "splicedb", "--workspace", "workspace", "--database", "database"},
+		{"--database-name", "splicedb", "--workspace", "workspace"},
+		{"--database-name", "splicedb", "--database", "database"},
+		{"--workspace", "splicedb", "--database", "workspace"},
+	} {
+		testDatabaseNameWithArray(t, args)
+	}
+}
+
+func testDatabaseNameWithArray(t *testing.T, args []string) {
+	tcmd := &cobra.Command{
+		Use: "test",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Flags().Visit(func(f *pflag.Flag) { fmt.Printf("%s: %s; ", f.Name, f.Value.String()) })
+			name := DatabaseName(cmd)
+			fmt.Println(name)
+			fmt.Println()
+			fmt.Println()
+			if name != "splicedb" {
+				t.Fatalf("database name shoud have been: 'splicedb'. but instead was: '%s'", name)
+			}
+		},
+	}
+	tcmd.Flags().StringP("database-name", "d", "", "")
+	tcmd.Flags().String("database", "", "")
+	tcmd.Flags().String("workspace", "", "")
+	tcmd.SetArgs(args)
+	tcmd.Execute()
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.0.0
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.3
 	github.com/stretchr/testify v1.4.0
 	gopkg.in/yaml.v2 v2.2.8


### PR DESCRIPTION
<!--
- Rebase your branch on the latest upstream master
- If this PR contains user facing change, please follow the checklist
- Provide a general summary of your changes in the Title above
-->

## Description
<!--- Describe your changes in detail -->

Added alias for subcommands that contain use the word database to now also use "workspace" and also added alias for flags that use --database-name to now also accept "database" and "workspace"

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As terminology surrounding the splice machine database has evolved, updating the naming conventions for commands in splicectl should evolve as well, so now there are aliases for the new and more concise names and old names could be deprecated in the future.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests have been written for the name deciding logic and the commands that were affected have been manually tested using various combinations of new names and old ones.

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [ ] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

### Changes

Commands that use "database" in their subcommands now also accept "workspace" which is the preferred and documented option now. Both options work, but help messages will now show "workspace" in their examples and usage docs.

Commands that accept the flag "--database-name/-d" now also accept the flags "workspace" and "database". This functionality is not provided by cobra, so instead some additional logic was added that will determine which name to use in the event that more that one of the flags is supplied with a value. The final order of preferredness is: "--database-name/-d"  > "workspace"  > "database" where "--database-name/-d" is always used if provided and "database" is only used if no other name flag has been provided.

There was one command that should have used the "database" subcommand naming convention but instead used splice-database, namely the `splicectl create splice-database`. That old syntax is still aliased for backwards compatibility, but the naming conventions have now been brought in line with the other database related commands and now also supports syntax like:
- `splicectl create workspace`
and 
- `splicectl create database`

No breaking changes have been implemented here, so all commands that used to work using the old names will still work.

## Checklist